### PR TITLE
fix: Removing Submit and Reset button movement logic in Wizard

### DIFF
--- a/blocks/form/components/wizard/wizard.js
+++ b/blocks/form/components/wizard/wizard.js
@@ -167,15 +167,6 @@ export class WizardLayout {
       });
     }
 
-    const resetBtn = panel.querySelector('.reset-wrapper');
-    if (resetBtn) {
-      wrapper.append(resetBtn);
-    }
-
-    const submitBtn = panel.querySelector('.submit-wrapper');
-    if (submitBtn) {
-      wrapper.append(submitBtn);
-    }
     this.assignIndexToSteps(panel);
     panel.append(wrapper);
     panel.querySelector('fieldset')?.classList.add('current-wizard-step');

--- a/test/unit/fixtures/form/claim.html
+++ b/test/unit/fixtures/form/claim.html
@@ -190,6 +190,8 @@
         <div class="text-wrapper field-insured-property-country1701932419758 field-wrapper" data-id="textinput-8b986fa9bb" data-required="false"><label
                 for="textinput-8b986fa9bb" class="field-label">Country (Optional)</label><input type="text"
                 id="textinput-8b986fa9bb" name="Insured_Property_Country1701932419758" autocomplete="off"></div>
+        <div class="button-wrapper field-reset1713344016774 field-wrapper reset-wrapper" data-id="reset-0d74964a9e">
+                <button type="reset" class="button" id="reset-0d74964a9e" name="reset1713344016774">Reset</button></div>
     </fieldset>
     <fieldset class="panel-wrapper field-panel-3 field-wrapper" data-id="panelcontainer-7f723ada4a" id="panelcontainer-7f723ada4a" name="panel_3"
         data-index="2" style="--wizard-step-index: 2;">
@@ -314,7 +316,5 @@
                 class="button" id="wizard-button-prev" name="back">Back</button></div>
         <div class="button-wrapper field-next field-wrapper wizard-button-next" data-id="wizard-button-next"><button type="button"
                 class="button" id="wizard-button-next" name="next">Next</button></div>
-        <div class="button-wrapper field-reset1713344016774 field-wrapper reset-wrapper" data-id="reset-0d74964a9e">
-                <button type="reset" class="button" id="reset-0d74964a9e" name="reset1713344016774">Reset</button></div>
     </div>
 </fieldset>

--- a/test/unit/fixtures/form/docBasedWizardForm.html
+++ b/test/unit/fixtures/form/docBasedWizardForm.html
@@ -37,11 +37,11 @@
             <div class="multiline-wrapper field-formcomments field-wrapper" data-fieldset="panel-4" data-id="formcomments" data-required-error-message="Please fill in this field." data-required="false"><label for="formcomments" class="field-label">Is there anything we should know before we contact you?</label><textarea id="formcomments" name="formComments" autocomplete="off"></textarea></div>
             <div class="hidden-wrapper field-wrapper" data-fieldset="panel-4" data-id="" data-required-error-message="Please fill in this field." data-required="false"><label for="" class="field-label">I would like to receive Shred-it emails</label><input type="hidden" id="" name="undefined" autocomplete="off" value=""></div>
             <div class="checkbox-wrapper field-newslettersignup field-wrapper" data-fieldset="panel-4" data-id="newslettersignup" data-required-error-message="Please fill in this field." data-required="false"><input type="checkbox" value="true" id="newslettersignup" name="newslettersignup" autocomplete="off"><label for="newslettersignup" class="field-label">I would like to receive Shred-it emails</label></div>
+            <div class="button-wrapper field-submitbutton field-wrapper submit-wrapper" data-fieldset="panel-4" data-id="submitbutton"><button type="submit" class="button" id="submitbutton" name="submitbutton">Submit</button></div>
         </fieldset>
         <div class="wizard-button-wrapper">
             <div class="button-wrapper field-back field-wrapper wizard-button-prev" data-id="wizard-button-prev"><button type="button" class="button" id="wizard-button-prev" name="back">Back</button></div>
             <div class="button-wrapper field-next field-wrapper wizard-button-next" data-id="wizard-button-next"><button type="button" class="button" id="wizard-button-next" name="next">Next</button></div>
-            <div class="button-wrapper field-submitbutton field-wrapper submit-wrapper" data-fieldset="panel-4" data-id="submitbutton"><button type="submit" class="button" id="submitbutton" name="submitbutton">Submit</button></div>
         </div>
     </fieldset>
     <div class="hidden-wrapper field-webform-identifier field-wrapper" data-id="webform-identifier" data-required-error-message="Please fill in this field." data-required="false"><label for="webform-identifier" class="field-label">Webform_Identifier</label><input type="hidden" id="webform-identifier" name="Webform_Identifier" autocomplete="off" value="CUSIT"></div>


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://ue-wizard-btns--aem-boilerplate-forms--adobe-rnd.aem.live/
