### PR TITLE
fix: field-invalid class not getting removed once field is valid

### DIFF
--- a/blocks/form/util.js
+++ b/blocks/form/util.js
@@ -177,6 +177,7 @@ export function updateOrCreateInvalidMsg(fieldElement, msg) {
     element.innerHTML = container.dataset.description;
   } else if (element) {
     element.remove();
+    container?.classList?.remove('field-invalid');
   }
   return element;
 }

--- a/test/unit/fixtures/dynamic/error-messages.js
+++ b/test/unit/fixtures/dynamic/error-messages.js
@@ -109,6 +109,7 @@ export function expect(block) {
   const f1Message = f1.querySelector('.field-invalid .field-description');
   assert.equal(f1Message.textContent, 'Please fill in this field.', 'Required error message for text input');
   setValue(block, '#f1', 'abc');
+  assert.equal(f1.classList.contains('.field-invalid'), false, 'field-invalid class not getting removed once field is valid');
   assert.equal(f1.querySelector('.field-invalid .field-description'), undefined, 'Not Required error message for text input');
 
   // number input error message


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/error-messages
- After: https://fix-error-message--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/error-messages
