### PR TITLE
fix: Allow navigation of accordion inside wizard in UE authoring

### DIFF
--- a/scripts/form-editor-support.js
+++ b/scripts/form-editor-support.js
@@ -197,7 +197,8 @@ export function handleEditorSelect(event) {
 
   if (selected && target.closest('.wizard') && !target.classList.contains('wizard')) {
     handleNavigation(target.closest('.wizard'), resource, handleWizardNavigation);
-  } else if (selected && target.closest('.accordion')) {
+  }
+  if (selected && target.closest('.accordion')) {
     handleNavigation(target.closest('.accordion'), resource, handleAccordionNavigationInEditor);
   }
 }


### PR DESCRIPTION
[Before Form](https://author-p133911-e1313554.adobeaemcloud.com/ui#/@formsinternal01/aem/universal-editor/canvas/author-p133911-e1313554.adobeaemcloud.com/content/forms/af/newboilerplate.html) navigation of accordion inside wizard wasnt working
[After form](https://author-p133911-e1313554.adobeaemcloud.com/ui#/@formsinternal01/aem/universal-editor/canvas/author-p133911-e1313554.adobeaemcloud.com/content/forms/af/newboilerplate.html?ref=ue-wizard-accordion) same accordion is navigable within wizard

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://ue-wizard-accordion--aem-boilerplate-forms--adobe-rnd.aem.live/
