### PR TITLE
fix: reset panel populates undefined in input fields

### DIFF
--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -86,35 +86,39 @@ async function fieldChanged(payload, form, generateFormRendition) {
         {
           const { validity } = payload.field;
           if (field.setCustomValidity
-          && (validity?.expressionMismatch || validity?.customConstraint)) {
+            && (validity?.expressionMismatch || validity?.customConstraint)) {
             field.setCustomValidity(currentValue);
             updateOrCreateInvalidMsg(field, currentValue);
           }
         }
         break;
       case 'value':
+        // Handle undefined currentValue to prevent "undefined" appearing in form fields
+        // eslint-disable-next-line no-case-declarations
+        const valueToSet = currentValue === undefined ? '' : currentValue;
+
         if (['number', 'date', 'text', 'email'].includes(field.type) && (displayFormat || displayValueExpression)) {
-          field.setAttribute('edit-value', currentValue);
+          field.setAttribute('edit-value', valueToSet);
           field.setAttribute('display-value', displayValue);
           if (document.activeElement !== field) {
             field.value = displayValue;
           }
         } else if (fieldType === 'radio-group' || fieldType === 'checkbox-group') {
           field.querySelectorAll(`input[name=${name}]`).forEach((el) => {
-            const exists = (Array.isArray(currentValue)
-              && currentValue.some((x) => compare(x, el.value, type.replace('[]', ''))))
-              || compare(currentValue, el.value, type);
+            const exists = (Array.isArray(valueToSet)
+              && valueToSet.some((x) => compare(x, el.value, type.replace('[]', ''))))
+              || compare(valueToSet, el.value, type);
             el.checked = exists;
           });
         } else if (fieldType === 'checkbox') {
-          field.checked = compare(currentValue, field.value, type);
+          field.checked = compare(valueToSet, field.value, type);
         } else if (fieldType === 'plain-text') {
-          field.innerHTML = currentValue;
+          field.innerHTML = valueToSet;
         } else if (fieldType === 'image') {
           const altText = field?.querySelector('img')?.alt || '';
-          field.querySelector('picture')?.replaceWith(createOptimizedPicture(field, currentValue, altText));
+          field.querySelector('picture')?.replaceWith(createOptimizedPicture(valueToSet, altText));
         } else if (field.type !== 'file') {
-          field.value = currentValue;
+          field.value = valueToSet;
         }
         break;
       case 'visible':

--- a/test/e2e/x-walk/actions/reset/reset.runtime.spec.js
+++ b/test/e2e/x-walk/actions/reset/reset.runtime.spec.js
@@ -53,12 +53,21 @@ test.describe('resetButton validation test', () => {
       // eslint-disable-next-line no-await-in-loop,max-len
       await fillField(page, title, inputValues);
     }
-    await page.getByRole('button', { name: 'Reset' }).click();
+    await page.getByRole('button', { name: 'Reset', exact: true }).click();
     // eslint-disable-next-line no-restricted-syntax
     for (const title of titles) {
       // eslint-disable-next-line no-await-in-loop,no-use-before-define
       await checkIfReset(page, title);
     }
+  });
+
+  test('Check reset for panel not populating fields with undefined', async ({ page }) => {
+    const testURL1 = '/content/aem-boilerplate-forms-xwalk-collaterals/reset-validation';
+    await openPage(page, testURL1);
+    const emailInput = await page.getByRole('group', { name: 'Panel' }).getByLabel('Test Field');
+    await emailInput.fill('test@adobe.com');
+    await page.getByRole('button', { name: 'Reset Panel' }).click();
+    await expect(emailInput).toHaveValue('');
   });
   // eslint-disable-next-line no-shadow
   const checkIfReset = async (page, ComponentsTitle) => {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/reset-validation
- After: https://reset--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/reset-validation
