### PR TITLE
feat: Edit fragment Button in property rail of Form Fragment

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,7 +32,7 @@ module.exports = {
       'drop-down': 19,
       email: 22,
       'file-input': 20,
-      'form-fragment': 15,
+      'form-fragment': 16,
       'form-image': 7,
       'multiline-input': 23,
       'number-input': 22,

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -30,6 +30,12 @@
                             "...": "../form-common/_basic-input-fields.json#/fields"
                         },
                         {
+                            "component": "open-fragment",
+                            "name": "openFragment",
+                            "label": "Open Fragment",
+                            "valueType": "boolean"
+                        },
+                        {
                             "component": "aem-content",
                             "name": "fragmentPath",
                             "label": "Fragment reference",

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -37,6 +37,7 @@
                         },
                         {
                             "component": "edit-fragment",
+                            "name": "editFragment",
                             "label": "Edit Fragment"
                         }
                     ]

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -37,9 +37,7 @@
                         },
                         {
                             "component": "edit-fragment",
-                            "name": "editFragment",
-                            "label": "Edit Fragment",
-                            "valueType": "boolean"
+                            "label": "Edit Fragment"
                         }
                     ]
                 },

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -30,16 +30,16 @@
                             "...": "../form-common/_basic-input-fields.json#/fields"
                         },
                         {
-                            "component": "open-fragment",
-                            "name": "openFragment",
-                            "label": "Open Fragment",
-                            "valueType": "boolean"
-                        },
-                        {
                             "component": "aem-content",
                             "name": "fragmentPath",
                             "label": "Fragment reference",
                             "valueType": "string"
+                        },
+                        {
+                            "component": "open-fragment",
+                            "name": "openFragment",
+                            "label": "Open Fragment",
+                            "valueType": "boolean"
                         }
                     ]
                 },

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -38,7 +38,8 @@
                         {
                             "component": "edit-fragment",
                             "name": "editFragment",
-                            "label": "Edit Fragment"
+                            "label": "Edit Fragment",
+                            "valueType": "boolean"
                         }
                     ]
                 },

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -36,9 +36,9 @@
                             "valueType": "string"
                         },
                         {
-                            "component": "open-fragment",
-                            "name": "openFragment",
-                            "label": "Open Fragment",
+                            "component": "edit-fragment",
+                            "name": "editFragment",
+                            "label": "Edit Fragment",
                             "valueType": "boolean"
                         }
                     ]

--- a/component-models.json
+++ b/component-models.json
@@ -1997,6 +1997,12 @@
             ]
           },
           {
+            "component": "open-fragment",
+            "name": "openFragment",
+            "label": "Open Fragment",
+            "valueType": "boolean"
+          },
+          {
             "component": "aem-content",
             "name": "fragmentPath",
             "label": "Fragment reference",

--- a/component-models.json
+++ b/component-models.json
@@ -1997,16 +1997,16 @@
             ]
           },
           {
-            "component": "open-fragment",
-            "name": "openFragment",
-            "label": "Open Fragment",
-            "valueType": "boolean"
-          },
-          {
             "component": "aem-content",
             "name": "fragmentPath",
             "label": "Fragment reference",
             "valueType": "string"
+          },
+          {
+            "component": "open-fragment",
+            "name": "openFragment",
+            "label": "Open Fragment",
+            "valueType": "boolean"
           }
         ]
       },

--- a/component-models.json
+++ b/component-models.json
@@ -2003,9 +2003,9 @@
             "valueType": "string"
           },
           {
-            "component": "open-fragment",
-            "name": "openFragment",
-            "label": "Open Fragment",
+            "component": "edit-fragment",
+            "name": "editFragment",
+            "label": "Edit Fragment",
             "valueType": "boolean"
           }
         ]

--- a/component-models.json
+++ b/component-models.json
@@ -2004,9 +2004,7 @@
           },
           {
             "component": "edit-fragment",
-            "name": "editFragment",
-            "label": "Edit Fragment",
-            "valueType": "boolean"
+            "label": "Edit Fragment"
           }
         ]
       },

--- a/component-models.json
+++ b/component-models.json
@@ -2004,6 +2004,7 @@
           },
           {
             "component": "edit-fragment",
+            "name": "editFragment",
             "label": "Edit Fragment"
           }
         ]

--- a/component-models.json
+++ b/component-models.json
@@ -2005,7 +2005,8 @@
           {
             "component": "edit-fragment",
             "name": "editFragment",
-            "label": "Edit Fragment"
+            "label": "Edit Fragment",
+            "valueType": "boolean"
           }
         ]
       },


### PR DESCRIPTION
<img width="269" height="114" alt="Screenshot 2025-07-31 at 6 13 24 PM" src="https://github.com/user-attachments/assets/f20cd392-e51b-448f-a04d-6546d13f41a7" />

Try out authoring here: https://author-p133911-e1313554.adobeaemcloud.com/ui#/@formsinternal01/aem/universal-editor/canvas/author-p133911-e1313554.adobeaemcloud.com/content/forms/af/newboilerplate.html?ref=edit-fragment

Extension: https://github.com/adobe-aem-forms/af-extensions/pull/14/files

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://edit-fragment--aem-boilerplate-forms--adobe-rnd.aem.live/
