### PR TITLE
feat: Form fragment to pick from forms root by default

### DIFF
--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -33,7 +33,10 @@
                             "component": "aem-content",
                             "name": "fragmentPath",
                             "label": "Fragment reference",
-                            "valueType": "string"
+                            "valueType": "string",
+                            "validation": {
+                                "rootPath": "/content/forms/af"
+                            }
                         },
                         {
                             "component": "edit-fragment",

--- a/component-models.json
+++ b/component-models.json
@@ -2000,7 +2000,10 @@
             "component": "aem-content",
             "name": "fragmentPath",
             "label": "Fragment reference",
-            "valueType": "string"
+            "valueType": "string",
+            "validation": {
+              "rootPath": "/content/forms/af"
+            }
           },
           {
             "component": "edit-fragment",


### PR DESCRIPTION
<img width="308" height="375" alt="Screenshot 2025-08-07 at 6 06 06 PM" src="https://github.com/user-attachments/assets/922500e2-c8be-4fac-b5e0-5ae48befa8a3" />


Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://fragment-root--aem-boilerplate-forms--adobe-rnd.aem.live/

Test authoring: https://author-p133911-e1313554.adobeaemcloud.com/ui#/@formsinternal01/aem/universal-editor/canvas/author-p133911-e1313554.adobeaemcloud.com/content/forms/af/newboilerplate.html?ref=fragment-root
