### PR TITLE
fix: value flickering for input fields with displayValue on mobile

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -182,8 +182,27 @@ function inputDecorator(field, element) {
       input.setAttribute('display-value', field.displayValue ?? '');
       input.type = 'text';
       input.value = field.displayValue ?? '';
-      input.addEventListener('touchstart', () => { input.type = field.type; }); // in mobile devices the input type needs to be toggled before focus
-      input.addEventListener('focus', () => handleFocus(input, field));
+      // Handle mobile touch events to enable native date picker
+      let isMobileTouch = false;
+      input.addEventListener('touchstart', () => {
+        isMobileTouch = true;
+        input.type = field.type;
+        // Set the edit value immediately to prevent empty field
+        const editValue = input.getAttribute('edit-value');
+        if (editValue) {
+          input.value = editValue;
+        }
+      });
+
+      input.addEventListener('focus', () => {
+        // Only change type on desktop or if not already changed by touchstart
+        if (!isMobileTouch && input.type !== field.type) {
+          input.type = field.type;
+        }
+        handleFocus(input, field);
+        // Reset mobile touch flag
+        isMobileTouch = false;
+      });
       input.addEventListener('blur', () => handleFocusOut(input));
     } else if (input.type !== 'file') {
       input.value = field.value ?? '';

--- a/test/unit/fixtures/dynamic/date-input-blur-mobile.js
+++ b/test/unit/fixtures/dynamic/date-input-blur-mobile.js
@@ -1,0 +1,38 @@
+import assert from 'assert';
+
+export const sample = {
+  items: [
+    {
+      id: 'datepicker-6dd0c75352',
+      fieldType: 'date-input',
+      name: 'dob',
+      visible: true,
+      type: 'string',
+      enabled: true,
+      readOnly: false,
+      displayFormat: 'd MMMM, y',
+      default: '2000-02-13',
+      label: {
+        visible: true,
+        value: 'Date Of Birth',
+      },
+      events: {
+        'custom:setProperty': ['$event.payload'],
+      },
+      format: 'date',
+    },
+  ],
+};
+
+function getValue(block, id, property = 'value') {
+  const input = block.querySelector(id);
+  return input[property];
+}
+
+export function expect(block) {
+  const inputEle = block.querySelector('#datepicker-6dd0c75352');
+  inputEle.dispatchEvent(new Event('touchstart'));
+  assert.equal(inputEle.type, 'date', 'Input type should change to date after touchstart');
+  inputEle.dispatchEvent(new Event('focus'));
+  assert.equal(inputEle.type, 'date', 'Input type should stay as date');
+}


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/number-validation/basic
- After: https://flicker--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/number-validation/basic
