### PR TITLE
fix: make subscribe work for custom components inside repeatable panel

### DIFF
--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -33,6 +33,7 @@ import { LOG_LEVEL } from '../constant.js';
 import { createOptimizedPicture } from '../../../scripts/aem.js';
 
 const formSubscriptions = {};
+const formModels = {};
 
 function disableElement(el, value) {
   el.toggleAttribute('disabled', value === true);
@@ -200,7 +201,7 @@ async function fieldChanged(payload, form, generateFormRendition) {
           const removeId = prevValue.id;
           field?.querySelector(`#${removeId}`)?.remove();
         } else {
-          generateFormRendition({ items: [currentValue] }, field?.querySelector('.repeat-wrapper'));
+          generateFormRendition({ items: [currentValue] }, field?.querySelector('.repeat-wrapper'), form.dataset?.id);
         }
         break;
       case 'activeChild': handleActiveChild(activeChild, form);
@@ -299,14 +300,14 @@ export async function loadRuleEngine(formDef, htmlForm, captcha, genFormRenditio
   const ruleEngine = await import('./model/afb-runtime.js');
   const form = ruleEngine.restoreFormInstance(formDef, data);
   window.myForm = form;
+  formModels[htmlForm.dataset?.id] = form;
   const subscriptions = formSubscriptions[htmlForm.dataset?.id];
-  if (subscriptions) {
-    subscriptions.forEach((subscription, id) => {
-      const { callback, fieldDiv } = subscription;
-      const model = form.getElement(id);
-      callback(fieldDiv, model, 'register');
-    });
-  }
+  subscriptions?.forEach((subscription, id) => {
+    const { callback, fieldDiv } = subscription;
+    const model = form.getElement(id);
+    callback(fieldDiv, model, 'register');
+  });
+
   form.subscribe((e) => {
     handleRuleEngineEvent(e, htmlForm, genFormRendition);
   }, 'fieldChanged');
@@ -401,6 +402,12 @@ export function subscribe(fieldDiv, formId, callback) {
     if (!subscriptions) {
       subscriptions = new Map();
       formSubscriptions[formId] = subscriptions;
+    }
+    // In case of custom components inside repeatable panels,
+    //  the subscribe callback is triggered after form is initialised
+    if (formModels[formId]) {
+      const form = formModels[formId];
+      callback(fieldDiv, form.getElement(fieldDiv?.dataset?.id), 'register');
     }
     // Add the new subscription to the existing map
     subscriptions.set(fieldDiv?.dataset?.id, { callback, fieldDiv });

--- a/icons/close.svg
+++ b/icons/close.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" version="1.1" viewBox="0 0 847 1058.75">
+<g><polygon class="fil0" points="54,88 390,423 54,759 88,792 423,457 759,792 792,759 457,423 792,88 759,54 423,390 88,54 "/></g>
+</svg>

--- a/test/e2e/x-walk/modal.runtime.spec.js
+++ b/test/e2e/x-walk/modal.runtime.spec.js
@@ -50,4 +50,28 @@ test.describe('Modal Form Test', () => {
     await textField.fill('Hello');
     await expect(textField).toHaveValue('Hello');
   });
+
+
+  test.only('check modal works in newly added repeatable panel', async ({ page }) => {
+    const url = '/content/aem-boilerplate-forms-xwalk-collaterals/subscribe';
+    await openPage(page, url);
+    const button = await page.getByText('Open PopUp').first();
+    await button.click();
+    const dialog = await page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    const closeButton = await page.getByRole('button', { name: 'Close' });
+    await closeButton.click();
+    await expect(dialog).toBeHidden();
+
+    const addButton = await page.getByText('Add Instance');
+    await addButton.click();
+
+    const button_two = await page.getByText('Open PopUp').nth(1);
+    await button_two.click();
+    const dialog_two = await page.getByRole('dialog'); // so we remove a dialog from the html when its closed so at a time we will have only one dialog
+    await expect(dialog_two).toBeVisible();
+    const closeButton_two = await page.getByRole('button', { name: 'Close' });
+    await closeButton_two.click();
+    await expect(dialog_two).toBeHidden();
+  });
 });

--- a/test/e2e/x-walk/modal.runtime.spec.js
+++ b/test/e2e/x-walk/modal.runtime.spec.js
@@ -52,7 +52,7 @@ test.describe('Modal Form Test', () => {
   });
 
 
-  test.only('check modal works in newly added repeatable panel', async ({ page }) => {
+  test('check modal works in newly added repeatable panel', async ({ page }) => {
     const url = '/content/aem-boilerplate-forms-xwalk-collaterals/subscribe';
     await openPage(page, url);
     const button = await page.getByText('Open PopUp').first();


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/subscribe
- After: https://subscribe--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/subscribe
