### PR TITLE
feat: Adding Component name in UE properties

### DIFF
--- a/blocks/form/_form.json
+++ b/blocks/form/_form.json
@@ -15,23 +15,74 @@
         }
       }
     },
-    {
-      "...": "./models/form-components/_*.json#/definitions"
-    },
     { 
       "...": "./components/accordion/_accordion.json#/definitions" 
+    },
+    {
+      "...": "./models/form-components/_recaptcha.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_checkbox-group.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_date-input.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_drop-down.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_email.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_file-input.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_button.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_fragment.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_image.json#/definitions"
     },
     { 
       "...": "./components/modal/_modal.json#/definitions" 
     },
+    {
+      "...": "./models/form-components/_number-input.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_panel.json#/definitions"
+    },
     { 
       "...": "./components/password/_password.json#/definitions" 
+    },
+    {
+      "...": "./models/form-components/_telephone-input.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_radio-group.json#/definitions"
     },
     { 
       "...": "./components/rating/_rating.json#/definitions" 
     },
+    {
+      "...": "./models/form-components/_reset-button.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_checkbox.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_text.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_submit-button.json#/definitions"
+    },
     { 
       "...": "./components/tnc/_tnc.json#/definitions" 
+    },
+    {
+      "...": "./models/form-components/_text-input.json#/definitions"
     },
     { 
       "...": "./components/wizard/_wizard.json#/definitions" 

--- a/blocks/form/components/accordion/_accordion.json
+++ b/blocks/form/components/accordion/_accordion.json
@@ -35,7 +35,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Accordion",
                     "collapsible": false,
                     "...": "../../models/form-common/_basic-input-fields.json"
                 },

--- a/blocks/form/components/password/_password.json
+++ b/blocks/form/components/password/_password.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Password",
+      "title": "Password Field",
       "id": "password",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/textinput/v1/textinput",
             "template": {
-              "jcr:title": "Password",
+              "jcr:title": "Password Field",
               "fieldType": "text-input",
               "fd:viewType": "password"
             }
@@ -24,7 +24,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Password Field",
           "collapsible": false,
           "...": "../../models/form-common/_basic-input-fields.json"
         },

--- a/blocks/form/components/rating/_rating.json
+++ b/blocks/form/components/rating/_rating.json
@@ -24,7 +24,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Rating",
           "collapsible": false,
           "...": "../../models/form-common/_basic-input-fields.json"
         },

--- a/blocks/form/components/tnc/_tnc.json
+++ b/blocks/form/components/tnc/_tnc.json
@@ -62,7 +62,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Terms and conditions",
           "collapsible": false,
           "fields": [
             {

--- a/blocks/form/models/form-components/_button.json
+++ b/blocks/form/models/form-components/_button.json
@@ -23,7 +23,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Form Button",
           "collapsible": false,
           "...": "../form-common/_basic-fields.json"
         },

--- a/blocks/form/models/form-components/_button.json
+++ b/blocks/form/models/form-components/_button.json
@@ -1,7 +1,7 @@
 {
   "definitions": [
     {
-      "title": "Button",
+      "title": "Form Button",
       "id": "form-button",
       "plugins": {
         "xwalk": {

--- a/blocks/form/models/form-components/_button.json
+++ b/blocks/form/models/form-components/_button.json
@@ -8,7 +8,7 @@
           "page": {
             "resourceType": "core/fd/components/form/button/v1/button",
             "template": {
-              "jcr:title": "Button",
+              "jcr:title": "Form Button",
               "fieldType": "button"
             }
           }

--- a/blocks/form/models/form-components/_checkbox-group.json
+++ b/blocks/form/models/form-components/_checkbox-group.json
@@ -33,7 +33,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Checkbox Group",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_checkbox.json
+++ b/blocks/form/models/form-components/_checkbox.json
@@ -24,7 +24,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Checkbox",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_checkbox.json
+++ b/blocks/form/models/form-components/_checkbox.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Checkbox",
+            "title": "Single Checkbox",
             "id": "checkbox",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
                         "template": {
-                            "jcr:title": "Checkbox",
+                            "jcr:title": "Single Checkbox",
                             "fieldType": "checkbox",
                             "checkedValue": "on"
                         }
@@ -24,7 +24,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Checkbox",
+                    "label": "Single Checkbox",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_date-input.json
+++ b/blocks/form/models/form-components/_date-input.json
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Date Input",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_date-input.json
+++ b/blocks/form/models/form-components/_date-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Date Input",
+            "title": "Date Picker",
             "id": "date-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/datepicker/v1/datepicker",
                         "template": {
-                            "jcr:title": "Date Input",
+                            "jcr:title": "Date Picker",
                             "fieldType": "date-input"
                         }
                     }
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Date Input",
+                    "label": "Date Picker",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_drop-down.json
+++ b/blocks/form/models/form-components/_drop-down.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Dropdown List",
+      "title": "Dropdown",
       "id": "drop-down",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/dropdown/v1/dropdown",
             "template": {
-              "jcr:title": "Drop Down List",
+              "jcr:title": "Dropdown",
               "fieldType": "drop-down",
               "enum": [
                 "0",
@@ -32,7 +32,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Drop Down List",
+          "label": "Dropdown",
           "collapsible": false,
           "fields": [
             {

--- a/blocks/form/models/form-components/_drop-down.json
+++ b/blocks/form/models/form-components/_drop-down.json
@@ -32,7 +32,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Drop Down List",
           "collapsible": false,
           "fields": [
             {

--- a/blocks/form/models/form-components/_email.json
+++ b/blocks/form/models/form-components/_email.json
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Email Input",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_email.json
+++ b/blocks/form/models/form-components/_email.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Email",
+            "title": "Email Field",
             "id": "email",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/emailinput/v1/emailinput",
                         "template": {
-                            "jcr:title": "Email Input",
+                            "jcr:title": "Email Field",
                             "fieldType": "email"
                         }
                     }
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Email Input",
+                    "label": "Email Field",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_file-input.json
+++ b/blocks/form/models/form-components/_file-input.json
@@ -33,7 +33,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "File Attachment",
                     "collapsible": false,
                     "...": "../form-common/_basic-input-fields.json"
                 },

--- a/blocks/form/models/form-components/_file-input.json
+++ b/blocks/form/models/form-components/_file-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "File Attachment",
+            "title": "File Upload",
             "id": "file-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/fileinput/v2/fileinput",
                         "template": {
-                            "jcr:title": "File Attachment",
+                            "jcr:title": "File Upload",
                             "fieldType": "file-input",
                             "accept": [
                                 "audio/*",
@@ -33,7 +33,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "File Attachment",
+                    "label": "File Upload",
                     "collapsible": false,
                     "...": "../form-common/_basic-input-fields.json"
                 },

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -8,7 +8,7 @@
                     "page": {
                         "resourceType": "core/fd/components/form/fragment/v1/fragment",
                         "template": {
-                            "jcr:title": "Fragment",
+                            "jcr:title": "Form Fragment",
                             "fieldType": "panel"
                         }
                     }
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Fragment",
+                    "label": "Form Fragment",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Fragment",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_image.json
+++ b/blocks/form/models/form-components/_image.json
@@ -21,97 +21,105 @@
             "id": "form-image",
             "fields": [
                 {
-                    "component": "text",
-                    "name": "name",
-                    "label": "Name",
-                    "valueType": "string",
-                    "required": true
-                },
-                {
-                    "component": "text",
-                    "name": "jcr:title",
-                    "label": "Title",
-                    "valueType": "string"
-                },
-                {
-                    "component": "reference",
-                    "valueType": "string",
-                    "name": "fileReference",
+                    "component": "container",
+                    "name": "basic",
                     "label": "Image",
-                    "multi": false
-                },
-                {
-                    "component": "text",
-                    "valueType": "string",
-                    "name": "altText",
-                    "label": "Alternate text"
-                },
-                {
-                    "component": "text",
-                    "name": "dataRef",
-                    "label": "Bind reference",
-                    "valueType": "string"
-                },
-                {
-                    "component": "boolean",
-                    "name": "visible",
-                    "label": "Show Component",
-                    "valueType": "boolean",
-                    "value": true
-                },
-                {
-                    "component": "select",
-                    "name": "colspan",
-                    "label": "Column Span",
-                    "valueType": "string",
-                    "options": [
+                    "collapsible": false,
+                    "fields": [
                         {
-                            "name": "1 column",
-                            "value": "1"
+                            "component": "text",
+                            "name": "name",
+                            "label": "Name",
+                            "valueType": "string",
+                            "required": true
                         },
                         {
-                            "name": "2 column",
-                            "value": "2"
+                            "component": "text",
+                            "name": "jcr:title",
+                            "label": "Title",
+                            "valueType": "string"
                         },
                         {
-                            "name": "3 column",
-                            "value": "3"
+                            "component": "reference",
+                            "valueType": "string",
+                            "name": "fileReference",
+                            "label": "Image",
+                            "multi": false
                         },
                         {
-                            "name": "4 column",
-                            "value": "4"
+                            "component": "text",
+                            "valueType": "string",
+                            "name": "altText",
+                            "label": "Alternate text"
                         },
                         {
-                            "name": "5 column",
-                            "value": "5"
+                            "component": "text",
+                            "name": "dataRef",
+                            "label": "Bind reference",
+                            "valueType": "string"
                         },
                         {
-                            "name": "6 column",
-                            "value": "6"
+                            "component": "boolean",
+                            "name": "visible",
+                            "label": "Show Component",
+                            "valueType": "boolean",
+                            "value": true
                         },
                         {
-                            "name": "7 column",
-                            "value": "7"
-                        },
-                        {
-                            "name": "8 column",
-                            "value": "8"
-                        },
-                        {
-                            "name": "9 column",
-                            "value": "9"
-                        },
-                        {
-                            "name": "10 column",
-                            "value": "10"
-                        },
-                        {
-                            "name": "11 column",
-                            "value": "11"
-                        },
-                        {
-                            "name": "12 column",
-                            "value": "12"
+                            "component": "select",
+                            "name": "colspan",
+                            "label": "Column Span",
+                            "valueType": "string",
+                            "options": [
+                                {
+                                    "name": "1 column",
+                                    "value": "1"
+                                },
+                                {
+                                    "name": "2 column",
+                                    "value": "2"
+                                },
+                                {
+                                    "name": "3 column",
+                                    "value": "3"
+                                },
+                                {
+                                    "name": "4 column",
+                                    "value": "4"
+                                },
+                                {
+                                    "name": "5 column",
+                                    "value": "5"
+                                },
+                                {
+                                    "name": "6 column",
+                                    "value": "6"
+                                },
+                                {
+                                    "name": "7 column",
+                                    "value": "7"
+                                },
+                                {
+                                    "name": "8 column",
+                                    "value": "8"
+                                },
+                                {
+                                    "name": "9 column",
+                                    "value": "9"
+                                },
+                                {
+                                    "name": "10 column",
+                                    "value": "10"
+                                },
+                                {
+                                    "name": "11 column",
+                                    "value": "11"
+                                },
+                                {
+                                    "name": "12 column",
+                                    "value": "12"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/blocks/form/models/form-components/_multiline-input.json
+++ b/blocks/form/models/form-components/_multiline-input.json
@@ -7,7 +7,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Multiline Input",
+          "label": "Text area",
           "collapsible": false,
           "fields": [
             {

--- a/blocks/form/models/form-components/_multiline-input.json
+++ b/blocks/form/models/form-components/_multiline-input.json
@@ -7,7 +7,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Multiline Input",
           "collapsible": false,
           "fields": [
             {

--- a/blocks/form/models/form-components/_number-input.json
+++ b/blocks/form/models/form-components/_number-input.json
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Number Input",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_number-input.json
+++ b/blocks/form/models/form-components/_number-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Number Input",
+            "title": "Number Field",
             "id": "number-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/numberinput/v1/numberinput",
                         "template": {
-                            "jcr:title": "Number Input",
+                            "jcr:title": "Number Field",
                             "fieldType": "number-input"
                         }
                     }
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Number Input",
+                    "label": "Number Field",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_panel.json
+++ b/blocks/form/models/form-components/_panel.json
@@ -24,7 +24,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Panel",
                     "collapsible": false,
                     "...": "../form-common/_basic-input-fields.json"
                 },

--- a/blocks/form/models/form-components/_panel.json
+++ b/blocks/form/models/form-components/_panel.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Panel",
+            "title": "Panel / Section",
             "id": "panel",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
                         "template": {
-                            "jcr:title": "Panel",
+                            "jcr:title": "Panel / Section",
                             "fieldType": "panel",
                             "minOccur": 1
                         }
@@ -24,7 +24,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Panel",
+                    "label": "Panel / Section",
                     "collapsible": false,
                     "...": "../form-common/_basic-input-fields.json"
                 },

--- a/blocks/form/models/form-components/_radio-group.json
+++ b/blocks/form/models/form-components/_radio-group.json
@@ -32,7 +32,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Radio Group",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_recaptcha.json
+++ b/blocks/form/models/form-components/_recaptcha.json
@@ -21,11 +21,19 @@
             "id": "captcha",
             "fields": [
                 {
-                    "component": "text",
-                    "name": "name",
-                    "label": "Name",
-                    "valueType": "string",
-                    "required": true
+                    "component": "container",
+                    "name": "basic",
+                    "label": "Captcha (Invisible)",
+                    "collapsible": false,
+                    "fields": [
+                        {
+                            "component": "text",
+                            "name": "name",
+                            "label": "Name",
+                            "valueType": "string",
+                            "required": true
+                        }
+                    ]
                 }
             ]
         }

--- a/blocks/form/models/form-components/_recaptcha.json
+++ b/blocks/form/models/form-components/_recaptcha.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Captcha (Invisible)",
+            "title": "Captcha (Invisible reCAPTCHA)",
             "id": "captcha",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
                         "template": {
-                            "jcr:title": "Captcha (Invisible)",
+                            "jcr:title": "Captcha (Invisible reCAPTCHA)",
                             "fieldType": "captcha"
                         }
                     }
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Captcha (Invisible)",
+                    "label": "Captcha (Invisible reCAPTCHA)",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_reset-button.json
+++ b/blocks/form/models/form-components/_reset-button.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Reset",
+      "title": "Reset Form Button",
       "id": "form-reset-button",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/actions/reset/v1/reset",
             "template": {
-              "jcr:title": "Reset",
+              "jcr:title": "Reset Form Button",
               "buttonType": "reset",
               "fieldType": "button"
             }
@@ -24,7 +24,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Reset Button",
+          "label": "Reset Form Button",
           "collapsible": false,
           "...": "../form-common/_basic-fields.json"
         },

--- a/blocks/form/models/form-components/_reset-button.json
+++ b/blocks/form/models/form-components/_reset-button.json
@@ -24,7 +24,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Reset Button",
           "collapsible": false,
           "...": "../form-common/_basic-fields.json"
         },

--- a/blocks/form/models/form-components/_submit-button.json
+++ b/blocks/form/models/form-components/_submit-button.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Submit",
+      "title": "Submit Form Button",
       "id": "form-submit-button",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/actions/submit/v1/submit",
             "template": {
-              "jcr:title": "Submit",
+              "jcr:title": "Submit Form Button",
               "buttonType": "submit",
               "fieldType": "button"
             }
@@ -24,7 +24,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Submit Button",
+          "label": "Submit Form Button",
           "collapsible": false,
           "...": "../form-common/_basic-fields.json"
         },

--- a/blocks/form/models/form-components/_submit-button.json
+++ b/blocks/form/models/form-components/_submit-button.json
@@ -24,7 +24,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Submit Button",
           "collapsible": false,
           "...": "../form-common/_basic-fields.json"
         },

--- a/blocks/form/models/form-components/_telephone-input.json
+++ b/blocks/form/models/form-components/_telephone-input.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Telephone input",
+      "title": "Phone Number Field",
       "id": "telephone-input",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
             "template": {
-              "jcr:title": "Telephone Input",
+              "jcr:title": "Phone Number Field",
               "fieldType": "text-input"
             }
           }
@@ -23,7 +23,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Telephone Input",
+          "label": "Phone Number Field",
           "collapsible": false,
           "fields": [
             {

--- a/blocks/form/models/form-components/_telephone-input.json
+++ b/blocks/form/models/form-components/_telephone-input.json
@@ -23,7 +23,7 @@
         {
           "component": "container",
           "name": "basic",
-          "label": "Basic",
+          "label": "Telephone Input",
           "collapsible": false,
           "fields": [
             {

--- a/blocks/form/models/form-components/_text-input.json
+++ b/blocks/form/models/form-components/_text-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Text Input",
+            "title": "Text Field",
             "id": "text-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/textinput/v1/textinput",
                         "template": {
-                            "jcr:title": "Text Input",
+                            "jcr:title": "Text Field",
                             "fieldType": "text-input"
                         }
                     }
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Text Input",
+                    "label": "Text Field",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_text-input.json
+++ b/blocks/form/models/form-components/_text-input.json
@@ -23,7 +23,7 @@
                 {
                     "component": "container",
                     "name": "basic",
-                    "label": "Basic",
+                    "label": "Text Input",
                     "collapsible": false,
                     "fields": [
                         {

--- a/blocks/form/models/form-components/_text.json
+++ b/blocks/form/models/form-components/_text.json
@@ -21,38 +21,40 @@
   "models": [
     {
       "id": "plain-text",
-      "component": "container",
-      "name": "basic",
-      "label": "Static Text / Display Text",
-      "collapsible": false,
       "fields": [
         {
-          "component": "text",
-          "name": "name",
-          "label": "Text",
-          "valueType": "string",
-          "required": true
-        },
-        {
-          "component": "text",
-          "name": "dataRef",
-          "label": "Bind reference",
-          "valueType": "string"
-        },
-        {
-          "component": "boolean",
-          "name": "visible",
-          "label": "Show Component",
-          "valueType": "boolean",
-          "value": true
-        },
-        {
-            "component": "select",
-            "name": "colspan",
-            "label": "Column Span",
-            "valueType": "string",
-            "value": "12",
-            "options": [
+          "component": "container",
+          "name": "basic",
+          "label": "Static Text / Display Text",
+          "collapsible": false,
+          "fields": [
+            {
+              "component": "text",
+              "name": "name",
+              "label": "Name",
+              "valueType": "string",
+              "required": true
+            },
+            {
+              "component": "text",
+              "name": "dataRef",
+              "label": "Bind reference",
+              "valueType": "string"
+            },
+            {
+              "component": "boolean",
+              "name": "visible",
+              "label": "Show Component",
+              "valueType": "boolean",
+              "value": true
+            },
+            {
+              "component": "select",
+              "name": "colspan",
+              "label": "Column Span",
+              "valueType": "string",
+              "value": "12",
+              "options": [
                 {
                     "name": "1 column",
                     "value": "1"
@@ -101,7 +103,9 @@
                     "name": "12 column",
                     "value": "12"
                 }
-            ]
+              ]
+            }
+          ]
         }
       ]
     }

--- a/blocks/form/models/form-components/_text.json
+++ b/blocks/form/models/form-components/_text.json
@@ -25,7 +25,7 @@
         {
           "component": "text",
           "name": "name",
-          "label": "Name",
+          "label": "Text",
           "valueType": "string",
           "required": true
         },

--- a/blocks/form/models/form-components/_text.json
+++ b/blocks/form/models/form-components/_text.json
@@ -21,11 +21,15 @@
   "models": [
     {
       "id": "plain-text",
+      "component": "container",
+      "name": "basic",
+      "label": "Static Text / Display Text",
+      "collapsible": false,
       "fields": [
         {
           "component": "text",
           "name": "name",
-          "label": "Static Text / Display Text",
+          "label": "Text",
           "valueType": "string",
           "required": true
         },

--- a/blocks/form/models/form-components/_text.json
+++ b/blocks/form/models/form-components/_text.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Text",
+      "title": "Static Text / Display Text",
       "id": "plain-text",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/text/v1/text",
             "template": {
-              "jcr:title": "Text",
+              "jcr:title": "Static Text / Display Text",
               "fieldType": "plain-text",
               "textIsRich": true,
               "value": "Adaptive Form Text Component"
@@ -25,7 +25,7 @@
         {
           "component": "text",
           "name": "name",
-          "label": "Text",
+          "label": "Static Text / Display Text",
           "valueType": "string",
           "required": true
         },

--- a/component-definition.json
+++ b/component-definition.json
@@ -516,14 +516,14 @@
           }
         },
         {
-          "title": "Password",
+          "title": "Password Field",
           "id": "password",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/textinput/v1/textinput",
                 "template": {
-                  "jcr:title": "Password",
+                  "jcr:title": "Password Field",
                   "fieldType": "text-input",
                   "fd:viewType": "password"
                 }

--- a/component-definition.json
+++ b/component-definition.json
@@ -158,7 +158,7 @@
           }
         },
         {
-          "title": "Button",
+          "title": "Form Button",
           "id": "form-button",
           "plugins": {
             "xwalk": {

--- a/component-definition.json
+++ b/component-definition.json
@@ -198,14 +198,14 @@
           }
         },
         {
-          "title": "Checkbox",
+          "title": "Single Checkbox",
           "id": "checkbox",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
                 "template": {
-                  "jcr:title": "Checkbox",
+                  "jcr:title": "Single Checkbox",
                   "fieldType": "checkbox",
                   "checkedValue": "on"
                 }
@@ -214,14 +214,14 @@
           }
         },
         {
-          "title": "Date Input",
+          "title": "Date Picker",
           "id": "date-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/datepicker/v1/datepicker",
                 "template": {
-                  "jcr:title": "Date Input",
+                  "jcr:title": "Date Picker",
                   "fieldType": "date-input"
                 }
               }
@@ -229,14 +229,14 @@
           }
         },
         {
-          "title": "Dropdown List",
+          "title": "Dropdown",
           "id": "drop-down",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/dropdown/v1/dropdown",
                 "template": {
-                  "jcr:title": "Drop Down List",
+                  "jcr:title": "Dropdown",
                   "fieldType": "drop-down",
                   "enum": [
                     "0",
@@ -253,14 +253,14 @@
           }
         },
         {
-          "title": "Email",
+          "title": "Email Field",
           "id": "email",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/emailinput/v1/emailinput",
                 "template": {
-                  "jcr:title": "Email Input",
+                  "jcr:title": "Email Field",
                   "fieldType": "email"
                 }
               }
@@ -268,14 +268,14 @@
           }
         },
         {
-          "title": "File Attachment",
+          "title": "File Upload",
           "id": "file-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/fileinput/v2/fileinput",
                 "template": {
-                  "jcr:title": "File Attachment",
+                  "jcr:title": "File Upload",
                   "fieldType": "file-input",
                   "accept": [
                     "audio/*",
@@ -300,7 +300,7 @@
               "page": {
                 "resourceType": "core/fd/components/form/fragment/v1/fragment",
                 "template": {
-                  "jcr:title": "Fragment",
+                  "jcr:title": "Form Fragment",
                   "fieldType": "panel"
                 }
               }
@@ -323,14 +323,14 @@
           }
         },
         {
-          "title": "Number Input",
+          "title": "Number Field",
           "id": "number-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/numberinput/v1/numberinput",
                 "template": {
-                  "jcr:title": "Number Input",
+                  "jcr:title": "Number Field",
                   "fieldType": "number-input"
                 }
               }
@@ -338,14 +338,14 @@
           }
         },
         {
-          "title": "Panel",
+          "title": "Panel / Section",
           "id": "panel",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
                 "template": {
-                  "jcr:title": "Panel",
+                  "jcr:title": "Panel / Section",
                   "fieldType": "panel",
                   "minOccur": 1
                 }
@@ -378,14 +378,14 @@
           }
         },
         {
-          "title": "Captcha (Invisible)",
+          "title": "Captcha (Invisible reCAPTCHA)",
           "id": "captcha",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
                 "template": {
-                  "jcr:title": "Captcha (Invisible)",
+                  "jcr:title": "Captcha (Invisible reCAPTCHA)",
                   "fieldType": "captcha"
                 }
               }
@@ -393,14 +393,14 @@
           }
         },
         {
-          "title": "Reset",
+          "title": "Reset Form Button",
           "id": "form-reset-button",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/actions/reset/v1/reset",
                 "template": {
-                  "jcr:title": "Reset",
+                  "jcr:title": "Reset Form Button",
                   "buttonType": "reset",
                   "fieldType": "button"
                 }
@@ -409,14 +409,14 @@
           }
         },
         {
-          "title": "Submit",
+          "title": "Submit Form Button",
           "id": "form-submit-button",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/actions/submit/v1/submit",
                 "template": {
-                  "jcr:title": "Submit",
+                  "jcr:title": "Submit Form Button",
                   "buttonType": "submit",
                   "fieldType": "button"
                 }
@@ -425,14 +425,14 @@
           }
         },
         {
-          "title": "Telephone input",
+          "title": "Phone Number Field",
           "id": "telephone-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
                 "template": {
-                  "jcr:title": "Telephone Input",
+                  "jcr:title": "Phone Number Field",
                   "fieldType": "text-input"
                 }
               }
@@ -440,14 +440,14 @@
           }
         },
         {
-          "title": "Text Input",
+          "title": "Text Field",
           "id": "text-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/textinput/v1/textinput",
                 "template": {
-                  "jcr:title": "Text Input",
+                  "jcr:title": "Text Field",
                   "fieldType": "text-input"
                 }
               }
@@ -455,14 +455,14 @@
           }
         },
         {
-          "title": "Text",
+          "title": "Static Text / Display Text",
           "id": "plain-text",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/text/v1/text",
                 "template": {
-                  "jcr:title": "Text",
+                  "jcr:title": "Static Text / Display Text",
                   "fieldType": "plain-text",
                   "textIsRich": true,
                   "value": "Adaptive Form Text Component"

--- a/component-definition.json
+++ b/component-definition.json
@@ -165,7 +165,7 @@
               "page": {
                 "resourceType": "core/fd/components/form/button/v1/button",
                 "template": {
-                  "jcr:title": "Button",
+                  "jcr:title": "Form Button",
                   "fieldType": "button"
                 }
               }

--- a/component-definition.json
+++ b/component-definition.json
@@ -158,15 +158,42 @@
           }
         },
         {
-          "title": "Form Button",
-          "id": "form-button",
+          "title": "Accordion",
+          "id": "form-accordion",
           "plugins": {
             "xwalk": {
               "page": {
-                "resourceType": "core/fd/components/form/button/v1/button",
+                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
                 "template": {
-                  "jcr:title": "Form Button",
-                  "fieldType": "button"
+                  "jcr:title": "Accordion",
+                  "fieldType": "panel",
+                  "fd:viewType": "accordion",
+                  "minOccur": 1,
+                  "panel1": {
+                    "jcr:title": "Item 1",
+                    "fieldType": "panel",
+                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
+                  },
+                  "panel2": {
+                    "jcr:title": "Item 2",
+                    "fieldType": "panel",
+                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Captcha (Invisible reCAPTCHA)",
+          "id": "captcha",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
+                "template": {
+                  "jcr:title": "Captcha (Invisible reCAPTCHA)",
+                  "fieldType": "captcha"
                 }
               }
             }
@@ -192,22 +219,6 @@
                   ],
                   "orientation": "horizontal",
                   "type": "string[]"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Single Checkbox",
-          "id": "checkbox",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
-                "template": {
-                  "jcr:title": "Single Checkbox",
-                  "fieldType": "checkbox",
-                  "checkedValue": "on"
                 }
               }
             }
@@ -293,6 +304,21 @@
           }
         },
         {
+          "title": "Form Button",
+          "id": "form-button",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/button/v1/button",
+                "template": {
+                  "jcr:title": "Form Button",
+                  "fieldType": "button"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Form Fragment",
           "id": "form-fragment",
           "plugins": {
@@ -317,6 +343,23 @@
                 "template": {
                   "jcr:title": "Image",
                   "fieldType": "image"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Modal",
+          "id": "form-modal",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
+                "template": {
+                  "jcr:title": "Modal",
+                  "fieldType": "panel",
+                  "fd:viewType": "modal",
+                  "visible": false
                 }
               }
             }
@@ -354,6 +397,37 @@
           }
         },
         {
+          "title": "Password Field",
+          "id": "password",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/textinput/v1/textinput",
+                "template": {
+                  "jcr:title": "Password Field",
+                  "fieldType": "text-input",
+                  "fd:viewType": "password"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Phone Number Field",
+          "id": "telephone-input",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
+                "template": {
+                  "jcr:title": "Phone Number Field",
+                  "fieldType": "text-input"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Radio Group",
           "id": "radio-group",
           "plugins": {
@@ -378,15 +452,16 @@
           }
         },
         {
-          "title": "Captcha (Invisible reCAPTCHA)",
-          "id": "captcha",
+          "title": "Rating",
+          "id": "rating",
           "plugins": {
             "xwalk": {
               "page": {
-                "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
+                "resourceType": "core/fd/components/form/numberinput/v1/numberinput",
                 "template": {
-                  "jcr:title": "Captcha (Invisible reCAPTCHA)",
-                  "fieldType": "captcha"
+                  "jcr:title": "Rating",
+                  "fieldType": "number-input",
+                  "fd:viewType": "rating"
                 }
               }
             }
@@ -409,46 +484,16 @@
           }
         },
         {
-          "title": "Submit Form Button",
-          "id": "form-submit-button",
+          "title": "Single Checkbox",
+          "id": "checkbox",
           "plugins": {
             "xwalk": {
               "page": {
-                "resourceType": "core/fd/components/form/actions/submit/v1/submit",
+                "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
                 "template": {
-                  "jcr:title": "Submit Form Button",
-                  "buttonType": "submit",
-                  "fieldType": "button"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Phone Number Field",
-          "id": "telephone-input",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
-                "template": {
-                  "jcr:title": "Phone Number Field",
-                  "fieldType": "text-input"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Text Field",
-          "id": "text-input",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/textinput/v1/textinput",
-                "template": {
-                  "jcr:title": "Text Field",
-                  "fieldType": "text-input"
+                  "jcr:title": "Single Checkbox",
+                  "fieldType": "checkbox",
+                  "checkedValue": "on"
                 }
               }
             }
@@ -472,76 +517,16 @@
           }
         },
         {
-          "title": "Accordion",
-          "id": "form-accordion",
+          "title": "Submit Form Button",
+          "id": "form-submit-button",
           "plugins": {
             "xwalk": {
               "page": {
-                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
+                "resourceType": "core/fd/components/form/actions/submit/v1/submit",
                 "template": {
-                  "jcr:title": "Accordion",
-                  "fieldType": "panel",
-                  "fd:viewType": "accordion",
-                  "minOccur": 1,
-                  "panel1": {
-                    "jcr:title": "Item 1",
-                    "fieldType": "panel",
-                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
-                  },
-                  "panel2": {
-                    "jcr:title": "Item 2",
-                    "fieldType": "panel",
-                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Modal",
-          "id": "form-modal",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
-                "template": {
-                  "jcr:title": "Modal",
-                  "fieldType": "panel",
-                  "fd:viewType": "modal",
-                  "visible": false
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Password Field",
-          "id": "password",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/textinput/v1/textinput",
-                "template": {
-                  "jcr:title": "Password Field",
-                  "fieldType": "text-input",
-                  "fd:viewType": "password"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Rating",
-          "id": "rating",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/numberinput/v1/numberinput",
-                "template": {
-                  "jcr:title": "Rating",
-                  "fieldType": "number-input",
-                  "fd:viewType": "rating"
+                  "jcr:title": "Submit Form Button",
+                  "buttonType": "submit",
+                  "fieldType": "button"
                 }
               }
             }
@@ -598,6 +583,21 @@
                       "true"
                     ]
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Text Field",
+          "id": "text-input",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/textinput/v1/textinput",
+                "template": {
+                  "jcr:title": "Text Field",
+                  "fieldType": "text-input"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -737,7 +737,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Checkbox",
+        "label": "Single Checkbox",
         "collapsible": false,
         "fields": [
           {
@@ -963,7 +963,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Date Input",
+        "label": "Date Picker",
         "collapsible": false,
         "fields": [
           {
@@ -1219,7 +1219,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Drop Down List",
+        "label": "Dropdown",
         "collapsible": false,
         "fields": [
           {
@@ -1459,7 +1459,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Email Input",
+        "label": "Email Field",
         "collapsible": false,
         "fields": [
           {
@@ -1687,7 +1687,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "File Attachment",
+        "label": "File Upload",
         "collapsible": false,
         "fields": [
           {
@@ -1898,7 +1898,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Fragment",
+        "label": "Form Fragment",
         "collapsible": false,
         "fields": [
           {
@@ -2195,7 +2195,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Multiline Input",
+        "label": "Text area",
         "collapsible": false,
         "fields": [
           {
@@ -2429,7 +2429,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Number Input",
+        "label": "Number Field",
         "collapsible": false,
         "fields": [
           {
@@ -2695,7 +2695,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Panel",
+        "label": "Panel / Section",
         "collapsible": false,
         "fields": [
           {
@@ -3224,7 +3224,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Captcha (Invisible)",
+        "label": "Captcha (Invisible reCAPTCHA)",
         "collapsible": false,
         "fields": [
           {
@@ -3244,7 +3244,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Reset Button",
+        "label": "Reset Form Button",
         "collapsible": false,
         "fields": [
           {
@@ -3366,7 +3366,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Submit Button",
+        "label": "Submit Form Button",
         "collapsible": false,
         "fields": [
           {
@@ -3488,7 +3488,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Telephone Input",
+        "label": "Phone Number Field",
         "collapsible": false,
         "fields": [
           {
@@ -3702,7 +3702,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Text Input",
+        "label": "Text Field",
         "collapsible": false,
         "fields": [
           {
@@ -3936,7 +3936,7 @@
       {
         "component": "text",
         "name": "name",
-        "label": "Text",
+        "label": "Static Text / Display Text",
         "valueType": "string",
         "required": true
       },

--- a/component-models.json
+++ b/component-models.json
@@ -366,7 +366,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Form Button",
         "collapsible": false,
         "fields": [
           {
@@ -488,7 +488,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Checkbox Group",
         "collapsible": false,
         "fields": [
           {
@@ -737,7 +737,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Checkbox",
         "collapsible": false,
         "fields": [
           {
@@ -963,7 +963,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Date Input",
         "collapsible": false,
         "fields": [
           {
@@ -1219,7 +1219,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Drop Down List",
         "collapsible": false,
         "fields": [
           {
@@ -1459,7 +1459,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Email Input",
         "collapsible": false,
         "fields": [
           {
@@ -1687,7 +1687,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "File Attachment",
         "collapsible": false,
         "fields": [
           {
@@ -1898,7 +1898,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Fragment",
         "collapsible": false,
         "fields": [
           {
@@ -2085,97 +2085,105 @@
     "id": "form-image",
     "fields": [
       {
-        "component": "text",
-        "name": "name",
-        "label": "Name",
-        "valueType": "string",
-        "required": true
-      },
-      {
-        "component": "text",
-        "name": "jcr:title",
-        "label": "Title",
-        "valueType": "string"
-      },
-      {
-        "component": "reference",
-        "valueType": "string",
-        "name": "fileReference",
+        "component": "container",
+        "name": "basic",
         "label": "Image",
-        "multi": false
-      },
-      {
-        "component": "text",
-        "valueType": "string",
-        "name": "altText",
-        "label": "Alternate text"
-      },
-      {
-        "component": "text",
-        "name": "dataRef",
-        "label": "Bind reference",
-        "valueType": "string"
-      },
-      {
-        "component": "boolean",
-        "name": "visible",
-        "label": "Show Component",
-        "valueType": "boolean",
-        "value": true
-      },
-      {
-        "component": "select",
-        "name": "colspan",
-        "label": "Column Span",
-        "valueType": "string",
-        "options": [
+        "collapsible": false,
+        "fields": [
           {
-            "name": "1 column",
-            "value": "1"
+            "component": "text",
+            "name": "name",
+            "label": "Name",
+            "valueType": "string",
+            "required": true
           },
           {
-            "name": "2 column",
-            "value": "2"
+            "component": "text",
+            "name": "jcr:title",
+            "label": "Title",
+            "valueType": "string"
           },
           {
-            "name": "3 column",
-            "value": "3"
+            "component": "reference",
+            "valueType": "string",
+            "name": "fileReference",
+            "label": "Image",
+            "multi": false
           },
           {
-            "name": "4 column",
-            "value": "4"
+            "component": "text",
+            "valueType": "string",
+            "name": "altText",
+            "label": "Alternate text"
           },
           {
-            "name": "5 column",
-            "value": "5"
+            "component": "text",
+            "name": "dataRef",
+            "label": "Bind reference",
+            "valueType": "string"
           },
           {
-            "name": "6 column",
-            "value": "6"
+            "component": "boolean",
+            "name": "visible",
+            "label": "Show Component",
+            "valueType": "boolean",
+            "value": true
           },
           {
-            "name": "7 column",
-            "value": "7"
-          },
-          {
-            "name": "8 column",
-            "value": "8"
-          },
-          {
-            "name": "9 column",
-            "value": "9"
-          },
-          {
-            "name": "10 column",
-            "value": "10"
-          },
-          {
-            "name": "11 column",
-            "value": "11"
-          },
-          {
-            "name": "12 column",
-            "value": "12"
+            "component": "select",
+            "name": "colspan",
+            "label": "Column Span",
+            "valueType": "string",
+            "options": [
+              {
+                "name": "1 column",
+                "value": "1"
+              },
+              {
+                "name": "2 column",
+                "value": "2"
+              },
+              {
+                "name": "3 column",
+                "value": "3"
+              },
+              {
+                "name": "4 column",
+                "value": "4"
+              },
+              {
+                "name": "5 column",
+                "value": "5"
+              },
+              {
+                "name": "6 column",
+                "value": "6"
+              },
+              {
+                "name": "7 column",
+                "value": "7"
+              },
+              {
+                "name": "8 column",
+                "value": "8"
+              },
+              {
+                "name": "9 column",
+                "value": "9"
+              },
+              {
+                "name": "10 column",
+                "value": "10"
+              },
+              {
+                "name": "11 column",
+                "value": "11"
+              },
+              {
+                "name": "12 column",
+                "value": "12"
+              }
+            ]
           }
         ]
       }
@@ -2187,7 +2195,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Multiline Input",
         "collapsible": false,
         "fields": [
           {
@@ -2421,7 +2429,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Number Input",
         "collapsible": false,
         "fields": [
           {
@@ -2687,7 +2695,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Panel",
         "collapsible": false,
         "fields": [
           {
@@ -2968,7 +2976,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Radio Group",
         "collapsible": false,
         "fields": [
           {
@@ -3214,11 +3222,19 @@
     "id": "captcha",
     "fields": [
       {
-        "component": "text",
-        "name": "name",
-        "label": "Name",
-        "valueType": "string",
-        "required": true
+        "component": "container",
+        "name": "basic",
+        "label": "Captcha (Invisible)",
+        "collapsible": false,
+        "fields": [
+          {
+            "component": "text",
+            "name": "name",
+            "label": "Name",
+            "valueType": "string",
+            "required": true
+          }
+        ]
       }
     ]
   },
@@ -3228,7 +3244,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Reset Button",
         "collapsible": false,
         "fields": [
           {
@@ -3350,7 +3366,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Submit Button",
         "collapsible": false,
         "fields": [
           {
@@ -3472,7 +3488,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Telephone Input",
         "collapsible": false,
         "fields": [
           {
@@ -3686,7 +3702,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Text Input",
         "collapsible": false,
         "fields": [
           {
@@ -3920,7 +3936,7 @@
       {
         "component": "text",
         "name": "name",
-        "label": "Name",
+        "label": "Text",
         "valueType": "string",
         "required": true
       },

--- a/component-models.json
+++ b/component-models.json
@@ -3932,85 +3932,89 @@
   },
   {
     "id": "plain-text",
-    "component": "container",
-    "name": "basic",
-    "label": "Static Text / Display Text",
-    "collapsible": false,
     "fields": [
       {
-        "component": "text",
-        "name": "name",
-        "label": "Text",
-        "valueType": "string",
-        "required": true
-      },
-      {
-        "component": "text",
-        "name": "dataRef",
-        "label": "Bind reference",
-        "valueType": "string"
-      },
-      {
-        "component": "boolean",
-        "name": "visible",
-        "label": "Show Component",
-        "valueType": "boolean",
-        "value": true
-      },
-      {
-        "component": "select",
-        "name": "colspan",
-        "label": "Column Span",
-        "valueType": "string",
-        "value": "12",
-        "options": [
+        "component": "container",
+        "name": "basic",
+        "label": "Static Text / Display Text",
+        "collapsible": false,
+        "fields": [
           {
-            "name": "1 column",
-            "value": "1"
+            "component": "text",
+            "name": "name",
+            "label": "Name",
+            "valueType": "string",
+            "required": true
           },
           {
-            "name": "2 column",
-            "value": "2"
+            "component": "text",
+            "name": "dataRef",
+            "label": "Bind reference",
+            "valueType": "string"
           },
           {
-            "name": "3 column",
-            "value": "3"
+            "component": "boolean",
+            "name": "visible",
+            "label": "Show Component",
+            "valueType": "boolean",
+            "value": true
           },
           {
-            "name": "4 column",
-            "value": "4"
-          },
-          {
-            "name": "5 column",
-            "value": "5"
-          },
-          {
-            "name": "6 column",
-            "value": "6"
-          },
-          {
-            "name": "7 column",
-            "value": "7"
-          },
-          {
-            "name": "8 column",
-            "value": "8"
-          },
-          {
-            "name": "9 column",
-            "value": "9"
-          },
-          {
-            "name": "10 column",
-            "value": "10"
-          },
-          {
-            "name": "11 column",
-            "value": "11"
-          },
-          {
-            "name": "12 column",
-            "value": "12"
+            "component": "select",
+            "name": "colspan",
+            "label": "Column Span",
+            "valueType": "string",
+            "value": "12",
+            "options": [
+              {
+                "name": "1 column",
+                "value": "1"
+              },
+              {
+                "name": "2 column",
+                "value": "2"
+              },
+              {
+                "name": "3 column",
+                "value": "3"
+              },
+              {
+                "name": "4 column",
+                "value": "4"
+              },
+              {
+                "name": "5 column",
+                "value": "5"
+              },
+              {
+                "name": "6 column",
+                "value": "6"
+              },
+              {
+                "name": "7 column",
+                "value": "7"
+              },
+              {
+                "name": "8 column",
+                "value": "8"
+              },
+              {
+                "name": "9 column",
+                "value": "9"
+              },
+              {
+                "name": "10 column",
+                "value": "10"
+              },
+              {
+                "name": "11 column",
+                "value": "11"
+              },
+              {
+                "name": "12 column",
+                "value": "12"
+              }
+            ]
           }
         ]
       }

--- a/component-models.json
+++ b/component-models.json
@@ -3932,11 +3932,15 @@
   },
   {
     "id": "plain-text",
+    "component": "container",
+    "name": "basic",
+    "label": "Static Text / Display Text",
+    "collapsible": false,
     "fields": [
       {
         "component": "text",
         "name": "name",
-        "label": "Static Text / Display Text",
+        "label": "Text",
         "valueType": "string",
         "required": true
       },
@@ -4018,7 +4022,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Accordion",
         "collapsible": false,
         "fields": [
           {
@@ -4310,7 +4314,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Password Field",
         "collapsible": false,
         "fields": [
           {
@@ -4743,7 +4747,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Rating",
         "collapsible": false,
         "fields": [
           {
@@ -4945,7 +4949,7 @@
       {
         "component": "container",
         "name": "basic",
-        "label": "Basic",
+        "label": "Terms and conditions",
         "collapsible": false,
         "fields": [
           {


### PR DESCRIPTION
In place of Basic label in the property rail showing component name . 
Changed the order of components as well. The components now come in sorted order:
<img width="402" height="295" alt="image" src="https://github.com/user-attachments/assets/a92505c8-ee16-4250-aea7-69705efdf6cb" />

Also changing the name of the components while adding it in Adaptive form 
before : 
<img width="247" height="839" alt="image" src="https://github.com/user-attachments/assets/c619560e-51fc-4cc4-b996-e48d2559a161" />
After:
<img width="236" height="841" alt="image" src="https://github.com/user-attachments/assets/612af18c-8c35-4eca-93a2-54f8163acfe9" />





Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #

Test URLs:

Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
After: https://basic2Componentname--aem-boilerplate-forms--adobe-rnd.aem.page/

Testing collateral :
https://author-p133911-e1313554.adobeaemcloud.com/ui#/@formsinternal01/aem/universal-editor/canvas/author-p133911-e1313554.adobeaemcloud.com/content/forms/af/lovely/xwalk-setup5.html
