### PR TITLE
fix: Rename Data type of submitted value to Save value as to align with CC

### DIFF
--- a/blocks/form/models/form-components/_checkbox-group.json
+++ b/blocks/form/models/form-components/_checkbox-group.json
@@ -57,7 +57,7 @@
                         },
                         {
                             "component": "select",
-                            "label": "Data type of submitted value",
+                            "label": "Save value as",
                             "name": "type",
                             "valueType": "string",
                             "value": "string[]",

--- a/blocks/form/models/form-components/_checkbox.json
+++ b/blocks/form/models/form-components/_checkbox.json
@@ -32,7 +32,7 @@
                         },
                         {
                             "component": "select",
-                            "label": "Data type of submitted value",
+                            "label": "Save value as",
                             "name": "type",
                             "valueType": "string",
                             "options": [

--- a/blocks/form/models/form-components/_drop-down.json
+++ b/blocks/form/models/form-components/_drop-down.json
@@ -46,7 +46,7 @@
             },
             {
               "component": "select",
-              "label": "Data type of submitted value",
+              "label": "Save value as",
               "name": "type",
               "valueType": "string",
               "value": "number",

--- a/blocks/form/models/form-components/_radio-group.json
+++ b/blocks/form/models/form-components/_radio-group.json
@@ -56,7 +56,7 @@
                         },
                         {
                             "component": "select",
-                            "label": "Data type of submitted value",
+                            "label": "Save value as",
                             "name": "type",
                             "valueType": "string",
                             "options": [

--- a/component-models.json
+++ b/component-models.json
@@ -643,7 +643,7 @@
           },
           {
             "component": "select",
-            "label": "Data type of submitted value",
+            "label": "Save value as",
             "name": "type",
             "valueType": "string",
             "value": "string[]",
@@ -855,7 +855,7 @@
           },
           {
             "component": "select",
-            "label": "Data type of submitted value",
+            "label": "Save value as",
             "name": "type",
             "valueType": "string",
             "options": [
@@ -1364,7 +1364,7 @@
           },
           {
             "component": "select",
-            "label": "Data type of submitted value",
+            "label": "Save value as",
             "name": "type",
             "valueType": "string",
             "value": "number",
@@ -3123,7 +3123,7 @@
           },
           {
             "component": "select",
-            "label": "Data type of submitted value",
+            "label": "Save value as",
             "name": "type",
             "valueType": "string",
             "options": [


### PR DESCRIPTION

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://dropdown-saveas--aem-boilerplate-forms--adobe-rnd.aem.live/
