### PR TITLE
[Do not Merge] FORMS-21451 Update Embed Adaptive Form block to use select-form extension

### DIFF
--- a/blocks/embed-adaptive-form/_embed-adaptive-form.json
+++ b/blocks/embed-adaptive-form/_embed-adaptive-form.json
@@ -21,7 +21,7 @@
             "id": "embed-adaptive-form",
             "fields": [
               {
-                  "component": "aem-content",
+                  "component": "select-form",
                   "valueType": "string",
                   "name": "formPath",
                   "value": "",

--- a/component-models.json
+++ b/component-models.json
@@ -159,7 +159,7 @@
     "id": "embed-adaptive-form",
     "fields": [
       {
-        "component": "aem-content",
+        "component": "select-form",
         "valueType": "string",
         "name": "formPath",
         "value": "",


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<FORMS-21451>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://form-selector--aem-boilerplate-forms--adobe-rnd.aem.live/
