### PR TITLE
feat: Adding hide/show rules of repetitions in form fragment

### DIFF
--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -9,7 +9,8 @@
                         "resourceType": "core/fd/components/form/fragment/v1/fragment",
                         "template": {
                             "jcr:title": "Fragment",
-                            "fieldType": "panel"
+                            "fieldType": "panel",
+                            "minOccur": 1
                         }
                     }
                 }
@@ -59,14 +60,30 @@
                     "name": "minOccur",
                     "label": "Minimum repetitions",
                     "valueType": "number",
-                    "description": "Minimum number of times the fragment appears on the form"
+                    "description": "Minimum number of times the fragment appears on the form",
+                    "condition": {
+                        "===": [
+                            {
+                                "var": "repeatable"
+                            },
+                            true
+                        ]
+                    }
                 },
                 {
                     "component": "number",
                     "name": "maxOccur",
                     "label": "Maximum repetitions",
                     "valueType": "number",
-                    "description": "Maximum number of times the fragment can appear on the form"
+                    "description": "Maximum number of times the fragment can appear on the form",
+                    "condition": {
+                        "===": [
+                            {
+                                "var": "repeatable"
+                            },
+                            true
+                        ]
+                    }
                 },
                 {
                     "...": "../form-common/_help-container.json#/fields"

--- a/component-definition.json
+++ b/component-definition.json
@@ -301,7 +301,8 @@
                 "resourceType": "core/fd/components/form/fragment/v1/fragment",
                 "template": {
                   "jcr:title": "Fragment",
-                  "fieldType": "panel"
+                  "fieldType": "panel",
+                  "minOccur": 1
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -1981,14 +1981,30 @@
         "name": "minOccur",
         "label": "Minimum repetitions",
         "valueType": "number",
-        "description": "Minimum number of times the fragment appears on the form"
+        "description": "Minimum number of times the fragment appears on the form",
+        "condition": {
+          "===": [
+            {
+              "var": "repeatable"
+            },
+            true
+          ]
+        }
       },
       {
         "component": "number",
         "name": "maxOccur",
         "label": "Maximum repetitions",
         "valueType": "number",
-        "description": "Maximum number of times the fragment can appear on the form"
+        "description": "Maximum number of times the fragment can appear on the form",
+        "condition": {
+          "===": [
+            {
+              "var": "repeatable"
+            },
+            true
+          ]
+        }
       },
       {
         "component": "tab",


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://forms-21654--aem-boilerplate-forms--adobe-rnd.aem.page/
