### PR TITLE
FORMS-21767: Form Submission Failure for Multiple Adaptive form in Page

### DIFF
--- a/blocks/form/rules/model/afb-runtime.js
+++ b/blocks/form/rules/model/afb-runtime.js
@@ -2092,6 +2092,9 @@ class Scriptable extends BaseNode {
         const funcName = action.isCustomEvent ? `custom_${action.type}` : action.type;
         const node = this.getCompiledEvent(eventName);
         const events = this._jsonModel.events?.[eventName];
+        if(eventName === 'submit'){
+            action.payload.action = '/adobe/forms/af/submit/' + btoa(this.form?._jsonModel?.properties['fd:path']);
+        }
         if (funcName in this && typeof this[funcName] === 'function') {
             this[funcName](action, context);
         }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

How to test : 
Go to form: https://author-p133911-e1313554.adobeaemcloud.com/content/forms/af/lovely/edsform-xwalks7.html
check the json: You'll notice the form name is given as such :  "form_1252567235"
Try to submit the form. It'll submit to : 
https://webhook.site/3aa7b4e1-7a23-46c0-b99c-81417a78499a

In case submission fails, try changing the webhook URL by editing the form through: https://author-p133911-e1313554.adobeaemcloud.com/ui#/@formsinternal01/aem/universal-editor/canvas/author-p133911-e1313554.adobeaemcloud.com/content/forms/af/lovely/edsform-xwalks7.html


Fix #FORMS-21767

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://submissionbug--aem-boilerplate-forms--adobe-rnd.aem.live/
