### PR TITLE
Adding Component names to Property rail.

### DIFF
--- a/blocks/form/_form.json
+++ b/blocks/form/_form.json
@@ -15,23 +15,74 @@
         }
       }
     },
-    {
-      "...": "./models/form-components/_*.json#/definitions"
-    },
     { 
       "...": "./components/accordion/_accordion.json#/definitions" 
+    },
+    {
+      "...": "./models/form-components/_recaptcha.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_checkbox-group.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_date-input.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_drop-down.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_email.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_file-input.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_button.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_fragment.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_image.json#/definitions"
     },
     { 
       "...": "./components/modal/_modal.json#/definitions" 
     },
+    {
+      "...": "./models/form-components/_number-input.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_panel.json#/definitions"
+    },
     { 
       "...": "./components/password/_password.json#/definitions" 
+    },
+    {
+      "...": "./models/form-components/_telephone-input.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_radio-group.json#/definitions"
     },
     { 
       "...": "./components/rating/_rating.json#/definitions" 
     },
+    {
+      "...": "./models/form-components/_reset-button.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_checkbox.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_text.json#/definitions"
+    },
+    {
+      "...": "./models/form-components/_submit-button.json#/definitions"
+    },
     { 
       "...": "./components/tnc/_tnc.json#/definitions" 
+    },
+    {
+      "...": "./models/form-components/_text-input.json#/definitions"
     },
     { 
       "...": "./components/wizard/_wizard.json#/definitions" 

--- a/blocks/form/components/accordion/_accordion.json
+++ b/blocks/form/components/accordion/_accordion.json
@@ -33,6 +33,12 @@
             "id": "accordion",
             "fields": [
                 {
+                    "component": "container",
+                    "name": "accordion_label",
+                    "label": "Accordion ",
+                    "collapsible": false
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/components/accordion/_accordion.json
+++ b/blocks/form/components/accordion/_accordion.json
@@ -35,7 +35,7 @@
                 {
                     "component": "container",
                     "name": "accordion_label",
-                    "label": "Accordion ",
+                    "label": "Accordion",
                     "collapsible": false,
                     "...": "../../models/form-common/_basic-input-fields.json"
                 },

--- a/blocks/form/components/accordion/_accordion.json
+++ b/blocks/form/components/accordion/_accordion.json
@@ -36,7 +36,8 @@
                     "component": "container",
                     "name": "accordion_label",
                     "label": "Accordion ",
-                    "collapsible": false
+                    "collapsible": false,
+                    "...": "../../models/form-common/_basic-input-fields.json"
                 },
                 {
                     "component": "tab",

--- a/blocks/form/components/password/_password.json
+++ b/blocks/form/components/password/_password.json
@@ -8,7 +8,7 @@
           "page": {
             "resourceType": "core/fd/components/form/textinput/v1/textinput",
             "template": {
-              "jcr:title": "Password",
+              "jcr:title": "Password Field",
               "fieldType": "text-input",
               "fd:viewType": "password"
             }
@@ -21,6 +21,12 @@
     {
       "id": "password",
       "fields": [
+        {
+          "component": "container",
+          "name": "password_field_label",
+          "label": "Password Field",
+          "collapsible": false
+        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/components/range/_range.json
+++ b/blocks/form/components/range/_range.json
@@ -24,6 +24,12 @@
         "id": "range",
         "fields": [
           {
+            "component": "container",
+            "name": "range_label",
+            "label": "Range",
+            "collapsible": false
+          },
+          {
             "component": "tab",
             "label": "Basic",
             "name": "basic"

--- a/blocks/form/components/rating/_rating.json
+++ b/blocks/form/components/rating/_rating.json
@@ -22,6 +22,12 @@
       "id": "rating",
       "fields": [
         {
+          "component": "container",
+          "name": "rating_label",
+          "label": "Rating",
+          "collapsible": false
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/components/tnc/_tnc.json
+++ b/blocks/form/components/tnc/_tnc.json
@@ -60,6 +60,12 @@
       "id": "tnc",
       "fields": [
         {
+          "component": "container",
+          "name": "tnc_label",
+          "label": "Terms and conditions",
+          "collapsible": false
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_button.json
+++ b/blocks/form/models/form-components/_button.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Button",
+      "title": "Form Button",
       "id": "form-button",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/button/v1/button",
             "template": {
-              "jcr:title": "Button",
+              "jcr:title": "Form Button",
               "fieldType": "button"
             }
           }
@@ -20,6 +20,12 @@
     {
       "id": "form-button",
       "fields": [
+        {
+          "component": "container",
+          "name": "button_label",
+          "label": "Form Button",
+          "collapsible": false
+        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_checkbox-group.json
+++ b/blocks/form/models/form-components/_checkbox-group.json
@@ -31,6 +31,12 @@
             "id": "checkbox-group",
             "fields": [
                 {
+                    "component": "container",
+                    "name": "checkbox_group_label",
+                    "label": "Checkbox Group",
+                    "collapsible": false
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_checkbox.json
+++ b/blocks/form/models/form-components/_checkbox.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Checkbox",
+            "title": "Single Checkbox",
             "id": "checkbox",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
                         "template": {
-                            "jcr:title": "Checkbox",
+                            "jcr:title": "Single Checkbox",
                             "fieldType": "checkbox",
                             "checkedValue": "on"
                         }
@@ -21,6 +21,12 @@
         {
             "id": "checkbox",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "checkbox_label",
+                    "label": "Single Checkbox",
+                    "collapsible": false
+                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_date-input.json
+++ b/blocks/form/models/form-components/_date-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Date Input",
+            "title": "Date Picker",
             "id": "date-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/datepicker/v1/datepicker",
                         "template": {
-                            "jcr:title": "Date Input",
+                            "jcr:title": "Date Picker",
                             "fieldType": "date-input"
                         }
                     }
@@ -20,6 +20,12 @@
         {
             "id": "date-input",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "date_picker_label",
+                    "label": "Date Picker",
+                    "collapsible": false
+                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_drop-down.json
+++ b/blocks/form/models/form-components/_drop-down.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Dropdown List",
+      "title": "Dropdown",
       "id": "drop-down",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/dropdown/v1/dropdown",
             "template": {
-              "jcr:title": "Drop Down List",
+              "jcr:title": "Drop Down",
               "fieldType": "drop-down",
               "enum": [
                 "0",
@@ -29,6 +29,12 @@
     {
       "id": "drop-down",
       "fields": [
+        {
+          "component": "container",
+          "name": "dropdown_label",
+          "label": "Dropdown",
+          "collapsible": false
+        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_email.json
+++ b/blocks/form/models/form-components/_email.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Email",
+            "title": "Email Field",
             "id": "email",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/emailinput/v1/emailinput",
                         "template": {
-                            "jcr:title": "Email Input",
+                            "jcr:title": "Email Field",
                             "fieldType": "email"
                         }
                     }
@@ -20,6 +20,12 @@
         {
             "id": "email",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "email_input_label",
+                    "label": "Email Field",
+                    "collapsible": false
+                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_file-input.json
+++ b/blocks/form/models/form-components/_file-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "File Attachment",
+            "title": "File Upload",
             "id": "file-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/fileinput/v2/fileinput",
                         "template": {
-                            "jcr:title": "File Attachment",
+                            "jcr:title": "File Upload",
                             "fieldType": "file-input",
                             "accept": [
                                 "audio/*",
@@ -30,6 +30,12 @@
         {
             "id": "file-input",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "file_upload_label",
+                    "label": "File Upload",
+                    "collapsible": false
+                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -8,7 +8,7 @@
                     "page": {
                         "resourceType": "core/fd/components/form/fragment/v1/fragment",
                         "template": {
-                            "jcr:title": "Fragment",
+                            "jcr:title": "Form Fragment",
                             "fieldType": "panel",
                             "minOccur": 1
                         }
@@ -21,6 +21,12 @@
         {
             "id": "form-fragment",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "form_fragment_label",
+                    "label": "Form Fragment",
+                    "collapsible": false
+                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_image.json
+++ b/blocks/form/models/form-components/_image.json
@@ -21,6 +21,12 @@
             "id": "form-image",
             "fields": [
                 {
+                    "component": "container",
+                    "name": "image_label",
+                    "label": "Image",
+                    "collapsible": false
+                },
+                {
                     "component": "text",
                     "name": "name",
                     "label": "Name",

--- a/blocks/form/models/form-components/_multiline-input.json
+++ b/blocks/form/models/form-components/_multiline-input.json
@@ -5,6 +5,12 @@
       "id": "multiline-input",
       "fields": [
         {
+          "component": "container",
+          "name": "text_area_label",
+          "label": "Text Area",
+          "collapsible": false
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_number-input.json
+++ b/blocks/form/models/form-components/_number-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Number Input",
+            "title": "Number Field",
             "id": "number-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/numberinput/v1/numberinput",
                         "template": {
-                            "jcr:title": "Number Input",
+                            "jcr:title": "Number Field",
                             "fieldType": "number-input"
                         }
                     }
@@ -20,6 +20,12 @@
         {
             "id": "number-input",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "number_field_label",
+                    "label": "Number Field",
+                    "collapsible": false
+                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_panel.json
+++ b/blocks/form/models/form-components/_panel.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Panel",
+            "title": "Panel / Section",
             "id": "panel",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
                         "template": {
-                            "jcr:title": "Panel",
+                            "jcr:title": "Panel / Section",
                             "fieldType": "panel",
                             "minOccur": 1
                         }
@@ -21,6 +21,12 @@
         {
             "id": "panel",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "panel_label",
+                    "label": "Panel / Section",
+                    "collapsible": false
+                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_radio-group.json
+++ b/blocks/form/models/form-components/_radio-group.json
@@ -30,6 +30,12 @@
             "id": "radio-group",
             "fields": [
                 {
+                    "component": "container",
+                    "name": "radio_group_label",
+                    "label": "Radio Group",
+                    "collapsible": false
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_recaptcha.json
+++ b/blocks/form/models/form-components/_recaptcha.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Captcha (Invisible)",
+            "title": "Captcha (Invisible reCAPTCHA)",
             "id": "captcha",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
                         "template": {
-                            "jcr:title": "Captcha (Invisible)",
+                            "jcr:title": "Captcha (Invisible reCAPTCHA)",
                             "fieldType": "captcha"
                         }
                     }
@@ -20,6 +20,12 @@
         {
             "id": "captcha",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "captcha_label",
+                    "label": "Captcha (Invisible reCAPTCHA)",
+                    "collapsible": false
+                },
                 {
                     "component": "text",
                     "name": "name",

--- a/blocks/form/models/form-components/_reset-button.json
+++ b/blocks/form/models/form-components/_reset-button.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Reset",
+      "title": "Reset Form Button",
       "id": "form-reset-button",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/actions/reset/v1/reset",
             "template": {
-              "jcr:title": "Reset",
+              "jcr:title": "Reset Form Button",
               "buttonType": "reset",
               "fieldType": "button"
             }
@@ -21,6 +21,12 @@
     {
       "id": "form-reset-button",
       "fields": [
+        {
+          "component": "container",
+          "name": "reset_button_label",
+          "label": "Reset Form Button",
+          "collapsible": false
+        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_submit-button.json
+++ b/blocks/form/models/form-components/_submit-button.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Submit",
+      "title": "Submit Form Button",
       "id": "form-submit-button",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/actions/submit/v1/submit",
             "template": {
-              "jcr:title": "Submit",
+              "jcr:title": "Submit Form Button",
               "buttonType": "submit",
               "fieldType": "button"
             }
@@ -21,6 +21,12 @@
     {
       "id": "form-submit-button",
       "fields": [
+        {
+          "component": "container",
+          "name": "submit_button_label",
+          "label": "Submit Form Button",
+          "collapsible": false
+        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_telephone-input.json
+++ b/blocks/form/models/form-components/_telephone-input.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Telephone input",
+      "title": "Phone Number Field",
       "id": "telephone-input",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
             "template": {
-              "jcr:title": "Telephone Input",
+              "jcr:title": "Phone Number Field",
               "fieldType": "text-input"
             }
           }
@@ -20,6 +20,12 @@
     {
       "id": "telephone-input",
       "fields": [
+        {
+          "component": "container",
+          "name": "phone_number_field_label",
+          "label": "Phone Number Field",
+          "collapsible": false
+        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_text-input.json
+++ b/blocks/form/models/form-components/_text-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Text Input",
+            "title": "Text Field",
             "id": "text-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/textinput/v1/textinput",
                         "template": {
-                            "jcr:title": "Text Input",
+                            "jcr:title": "Text Field",
                             "fieldType": "text-input"
                         }
                     }
@@ -20,6 +20,12 @@
         {
             "id": "text-input",
             "fields": [
+                {
+                    "component": "container",
+                    "name": "text_field_label",
+                    "label": "Text Field",
+                    "collapsible": false
+                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_text.json
+++ b/blocks/form/models/form-components/_text.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Text",
+      "title": "Static Text / Display Text",
       "id": "plain-text",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/text/v1/text",
             "template": {
-              "jcr:title": "Text",
+              "jcr:title": "Static Text / Display Text",
               "fieldType": "plain-text",
               "textIsRich": true,
               "value": "Adaptive Form Text Component"
@@ -22,6 +22,12 @@
     {
       "id": "plain-text",
       "fields": [
+        {
+          "component": "container",
+          "name": "static_text_label",
+          "label": "Static Text / Display Text",
+          "collapsible": false
+        },
         {
           "component": "text",
           "name": "name",

--- a/component-definition.json
+++ b/component-definition.json
@@ -158,15 +158,42 @@
           }
         },
         {
-          "title": "Button",
-          "id": "form-button",
+          "title": "Accordion",
+          "id": "form-accordion",
           "plugins": {
             "xwalk": {
               "page": {
-                "resourceType": "core/fd/components/form/button/v1/button",
+                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
                 "template": {
-                  "jcr:title": "Button",
-                  "fieldType": "button"
+                  "jcr:title": "Accordion",
+                  "fieldType": "panel",
+                  "fd:viewType": "accordion",
+                  "minOccur": 1,
+                  "panel1": {
+                    "jcr:title": "Item 1",
+                    "fieldType": "panel",
+                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
+                  },
+                  "panel2": {
+                    "jcr:title": "Item 2",
+                    "fieldType": "panel",
+                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Captcha (Invisible reCAPTCHA)",
+          "id": "captcha",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
+                "template": {
+                  "jcr:title": "Captcha (Invisible reCAPTCHA)",
+                  "fieldType": "captcha"
                 }
               }
             }
@@ -198,30 +225,14 @@
           }
         },
         {
-          "title": "Checkbox",
-          "id": "checkbox",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
-                "template": {
-                  "jcr:title": "Checkbox",
-                  "fieldType": "checkbox",
-                  "checkedValue": "on"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Date Input",
+          "title": "Date Picker",
           "id": "date-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/datepicker/v1/datepicker",
                 "template": {
-                  "jcr:title": "Date Input",
+                  "jcr:title": "Date Picker",
                   "fieldType": "date-input"
                 }
               }
@@ -229,14 +240,14 @@
           }
         },
         {
-          "title": "Dropdown List",
+          "title": "Dropdown",
           "id": "drop-down",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/dropdown/v1/dropdown",
                 "template": {
-                  "jcr:title": "Drop Down List",
+                  "jcr:title": "Drop Down",
                   "fieldType": "drop-down",
                   "enum": [
                     "0",
@@ -253,14 +264,14 @@
           }
         },
         {
-          "title": "Email",
+          "title": "Email Field",
           "id": "email",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/emailinput/v1/emailinput",
                 "template": {
-                  "jcr:title": "Email Input",
+                  "jcr:title": "Email Field",
                   "fieldType": "email"
                 }
               }
@@ -268,14 +279,14 @@
           }
         },
         {
-          "title": "File Attachment",
+          "title": "File Upload",
           "id": "file-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/fileinput/v2/fileinput",
                 "template": {
-                  "jcr:title": "File Attachment",
+                  "jcr:title": "File Upload",
                   "fieldType": "file-input",
                   "accept": [
                     "audio/*",
@@ -293,6 +304,21 @@
           }
         },
         {
+          "title": "Form Button",
+          "id": "form-button",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/button/v1/button",
+                "template": {
+                  "jcr:title": "Form Button",
+                  "fieldType": "button"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Form Fragment",
           "id": "form-fragment",
           "plugins": {
@@ -300,7 +326,7 @@
               "page": {
                 "resourceType": "core/fd/components/form/fragment/v1/fragment",
                 "template": {
-                  "jcr:title": "Fragment",
+                  "jcr:title": "Form Fragment",
                   "fieldType": "panel",
                   "minOccur": 1
                 }
@@ -324,14 +350,31 @@
           }
         },
         {
-          "title": "Number Input",
+          "title": "Modal",
+          "id": "form-modal",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
+                "template": {
+                  "jcr:title": "Modal",
+                  "fieldType": "panel",
+                  "fd:viewType": "modal",
+                  "visible": false
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Number Field",
           "id": "number-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/numberinput/v1/numberinput",
                 "template": {
-                  "jcr:title": "Number Input",
+                  "jcr:title": "Number Field",
                   "fieldType": "number-input"
                 }
               }
@@ -339,16 +382,47 @@
           }
         },
         {
-          "title": "Panel",
+          "title": "Panel / Section",
           "id": "panel",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
                 "template": {
-                  "jcr:title": "Panel",
+                  "jcr:title": "Panel / Section",
                   "fieldType": "panel",
                   "minOccur": 1
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Password",
+          "id": "password",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/textinput/v1/textinput",
+                "template": {
+                  "jcr:title": "Password Field",
+                  "fieldType": "text-input",
+                  "fd:viewType": "password"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Phone Number Field",
+          "id": "telephone-input",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
+                "template": {
+                  "jcr:title": "Phone Number Field",
+                  "fieldType": "text-input"
                 }
               }
             }
@@ -379,160 +453,6 @@
           }
         },
         {
-          "title": "Captcha (Invisible)",
-          "id": "captcha",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
-                "template": {
-                  "jcr:title": "Captcha (Invisible)",
-                  "fieldType": "captcha"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Reset",
-          "id": "form-reset-button",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/actions/reset/v1/reset",
-                "template": {
-                  "jcr:title": "Reset",
-                  "buttonType": "reset",
-                  "fieldType": "button"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Submit",
-          "id": "form-submit-button",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/actions/submit/v1/submit",
-                "template": {
-                  "jcr:title": "Submit",
-                  "buttonType": "submit",
-                  "fieldType": "button"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Telephone input",
-          "id": "telephone-input",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
-                "template": {
-                  "jcr:title": "Telephone Input",
-                  "fieldType": "text-input"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Text Input",
-          "id": "text-input",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/textinput/v1/textinput",
-                "template": {
-                  "jcr:title": "Text Input",
-                  "fieldType": "text-input"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Text",
-          "id": "plain-text",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/text/v1/text",
-                "template": {
-                  "jcr:title": "Text",
-                  "fieldType": "plain-text",
-                  "textIsRich": true,
-                  "value": "Adaptive Form Text Component"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Accordion",
-          "id": "form-accordion",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
-                "template": {
-                  "jcr:title": "Accordion",
-                  "fieldType": "panel",
-                  "fd:viewType": "accordion",
-                  "minOccur": 1,
-                  "panel1": {
-                    "jcr:title": "Item 1",
-                    "fieldType": "panel",
-                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
-                  },
-                  "panel2": {
-                    "jcr:title": "Item 2",
-                    "fieldType": "panel",
-                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Modal",
-          "id": "form-modal",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
-                "template": {
-                  "jcr:title": "Modal",
-                  "fieldType": "panel",
-                  "fd:viewType": "modal",
-                  "visible": false
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Password",
-          "id": "password",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/textinput/v1/textinput",
-                "template": {
-                  "jcr:title": "Password",
-                  "fieldType": "text-input",
-                  "fd:viewType": "password"
-                }
-              }
-            }
-          }
-        },
-        {
           "title": "Rating",
           "id": "rating",
           "plugins": {
@@ -543,6 +463,71 @@
                   "jcr:title": "Rating",
                   "fieldType": "number-input",
                   "fd:viewType": "rating"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Reset Form Button",
+          "id": "form-reset-button",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/actions/reset/v1/reset",
+                "template": {
+                  "jcr:title": "Reset Form Button",
+                  "buttonType": "reset",
+                  "fieldType": "button"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Single Checkbox",
+          "id": "checkbox",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
+                "template": {
+                  "jcr:title": "Single Checkbox",
+                  "fieldType": "checkbox",
+                  "checkedValue": "on"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Static Text / Display Text",
+          "id": "plain-text",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/text/v1/text",
+                "template": {
+                  "jcr:title": "Static Text / Display Text",
+                  "fieldType": "plain-text",
+                  "textIsRich": true,
+                  "value": "Adaptive Form Text Component"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Submit Form Button",
+          "id": "form-submit-button",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/actions/submit/v1/submit",
+                "template": {
+                  "jcr:title": "Submit Form Button",
+                  "buttonType": "submit",
+                  "fieldType": "button"
                 }
               }
             }
@@ -599,6 +584,21 @@
                       "true"
                     ]
                   }
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Text Field",
+          "id": "text-input",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/textinput/v1/textinput",
+                "template": {
+                  "jcr:title": "Text Field",
+                  "fieldType": "text-input"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -388,6 +388,12 @@
     "id": "form-button",
     "fields": [
       {
+        "component": "container",
+        "name": "button_label",
+        "label": "Form Button",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -503,6 +509,12 @@
   {
     "id": "checkbox-group",
     "fields": [
+      {
+        "component": "container",
+        "name": "checkbox_group_label",
+        "label": "Checkbox Group",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -744,6 +756,12 @@
     "id": "checkbox",
     "fields": [
       {
+        "component": "container",
+        "name": "checkbox_label",
+        "label": "Single Checkbox",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -960,6 +978,12 @@
   {
     "id": "date-input",
     "fields": [
+      {
+        "component": "container",
+        "name": "date_picker_label",
+        "label": "Date Picker",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -1205,6 +1229,12 @@
     "id": "drop-down",
     "fields": [
       {
+        "component": "container",
+        "name": "dropdown_label",
+        "label": "Dropdown",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1436,6 +1466,12 @@
     "id": "email",
     "fields": [
       {
+        "component": "container",
+        "name": "email_input_label",
+        "label": "Email Field",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1655,6 +1691,12 @@
     "id": "file-input",
     "fields": [
       {
+        "component": "container",
+        "name": "file_upload_label",
+        "label": "File Upload",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1857,6 +1899,12 @@
     "id": "form-fragment",
     "fields": [
       {
+        "component": "container",
+        "name": "form_fragment_label",
+        "label": "Form Fragment",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -2053,6 +2101,12 @@
     "id": "form-image",
     "fields": [
       {
+        "component": "container",
+        "name": "image_label",
+        "label": "Image",
+        "collapsible": false
+      },
+      {
         "component": "text",
         "name": "name",
         "label": "Name",
@@ -2152,6 +2206,12 @@
   {
     "id": "multiline-input",
     "fields": [
+      {
+        "component": "container",
+        "name": "text_area_label",
+        "label": "Text Area",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -2377,6 +2437,12 @@
   {
     "id": "number-input",
     "fields": [
+      {
+        "component": "container",
+        "name": "number_field_label",
+        "label": "Number Field",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -2631,6 +2697,12 @@
   {
     "id": "panel",
     "fields": [
+      {
+        "component": "container",
+        "name": "panel_label",
+        "label": "Panel / Section",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -2904,6 +2976,12 @@
     "id": "radio-group",
     "fields": [
       {
+        "component": "container",
+        "name": "radio_group_label",
+        "label": "Radio Group",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -3143,6 +3221,12 @@
     "id": "captcha",
     "fields": [
       {
+        "component": "container",
+        "name": "captcha_label",
+        "label": "Captcha (Invisible reCAPTCHA)",
+        "collapsible": false
+      },
+      {
         "component": "text",
         "name": "name",
         "label": "Name",
@@ -3154,6 +3238,12 @@
   {
     "id": "form-reset-button",
     "fields": [
+      {
+        "component": "container",
+        "name": "reset_button_label",
+        "label": "Reset Form Button",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3271,6 +3361,12 @@
     "id": "form-submit-button",
     "fields": [
       {
+        "component": "container",
+        "name": "submit_button_label",
+        "label": "Submit Form Button",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -3386,6 +3482,12 @@
   {
     "id": "telephone-input",
     "fields": [
+      {
+        "component": "container",
+        "name": "phone_number_field_label",
+        "label": "Phone Number Field",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3591,6 +3693,12 @@
   {
     "id": "text-input",
     "fields": [
+      {
+        "component": "container",
+        "name": "text_field_label",
+        "label": "Text Field",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3817,6 +3925,12 @@
     "id": "plain-text",
     "fields": [
       {
+        "component": "container",
+        "name": "static_text_label",
+        "label": "Static Text / Display Text",
+        "collapsible": false
+      },
+      {
         "component": "text",
         "name": "name",
         "label": "Name",
@@ -3898,6 +4012,12 @@
   {
     "id": "accordion",
     "fields": [
+      {
+        "component": "container",
+        "name": "accordion_label",
+        "label": "Accordion ",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -4179,6 +4299,12 @@
     "id": "password",
     "fields": [
       {
+        "component": "container",
+        "name": "password_field_label",
+        "label": "Password Field",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4386,6 +4512,12 @@
     "id": "range",
     "fields": [
       {
+        "component": "container",
+        "name": "range_label",
+        "label": "Range",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4591,6 +4723,12 @@
     "id": "rating",
     "fields": [
       {
+        "component": "container",
+        "name": "rating_label",
+        "label": "Rating",
+        "collapsible": false
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4783,6 +4921,12 @@
   {
     "id": "tnc",
     "fields": [
+      {
+        "component": "container",
+        "name": "tnc_label",
+        "label": "Terms and conditions",
+        "collapsible": false
+      },
       {
         "component": "tab",
         "label": "Basic",

--- a/component-models.json
+++ b/component-models.json
@@ -4016,7 +4016,122 @@
         "component": "container",
         "name": "accordion_label",
         "label": "Accordion ",
-        "collapsible": false
+        "collapsible": false,
+        "fields": [
+          {
+            "component": "text",
+            "name": "name",
+            "label": "Name",
+            "valueType": "string",
+            "required": true,
+            "valueFormat": "regexp",
+            "validation": {
+              "regExp": "^[^$].*",
+              "customErrorMsg": "Name cannot start with $"
+            }
+          },
+          {
+            "component": "text",
+            "name": "jcr:title",
+            "label": "Title",
+            "valueType": "string"
+          },
+          {
+            "component": "boolean",
+            "name": "hideTitle",
+            "label": "Hide title",
+            "valueType": "boolean"
+          },
+          {
+            "component": "datasource-bindref",
+            "name": "dataRef",
+            "label": "Bind reference",
+            "valueType": "string"
+          },
+          {
+            "component": "boolean",
+            "name": "unboundFormElement",
+            "label": "Mark as Unbound Form Element",
+            "valueType": "boolean"
+          },
+          {
+            "component": "boolean",
+            "name": "visible",
+            "label": "Show Component",
+            "valueType": "boolean",
+            "value": true
+          },
+          {
+            "component": "boolean",
+            "name": "enabled",
+            "label": "Enable Component",
+            "valueType": "boolean",
+            "value": true
+          },
+          {
+            "component": "boolean",
+            "name": "readOnly",
+            "label": "Read-only",
+            "valueType": "boolean"
+          },
+          {
+            "component": "select",
+            "name": "colspan",
+            "label": "Column Span",
+            "valueType": "string",
+            "value": "12",
+            "options": [
+              {
+                "name": "1 column",
+                "value": "1"
+              },
+              {
+                "name": "2 column",
+                "value": "2"
+              },
+              {
+                "name": "3 column",
+                "value": "3"
+              },
+              {
+                "name": "4 column",
+                "value": "4"
+              },
+              {
+                "name": "5 column",
+                "value": "5"
+              },
+              {
+                "name": "6 column",
+                "value": "6"
+              },
+              {
+                "name": "7 column",
+                "value": "7"
+              },
+              {
+                "name": "8 column",
+                "value": "8"
+              },
+              {
+                "name": "9 column",
+                "value": "9"
+              },
+              {
+                "name": "10 column",
+                "value": "10"
+              },
+              {
+                "name": "11 column",
+                "value": "11"
+              },
+              {
+                "name": "12 column",
+                "value": "12"
+              }
+            ]
+          }
+        ]
       },
       {
         "component": "tab",

--- a/component-models.json
+++ b/component-models.json
@@ -4015,7 +4015,7 @@
       {
         "component": "container",
         "name": "accordion_label",
-        "label": "Accordion ",
+        "label": "Accordion",
         "collapsible": false,
         "fields": [
           {

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,0 +1,5 @@
+mountpoints:
+  /:
+    url: https://author-p133911-e1313554.adobeaemcloud.com/bin/franklin.delivery/lovelymandal16/xwalk-s8/main
+    type: "markup"
+    suffix: ".html"

--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,5 +1,0 @@
-mountpoints:
-  /:
-    url: https://author-p133911-e1313554.adobeaemcloud.com/bin/franklin.delivery/lovelymandal16/xwalk-s8/main
-    type: "markup"
-    suffix: ".html"


### PR DESCRIPTION
Adding Component names to Property rail.
Testing collateral : Open the form in Author mode 
https://author-p133911-e1313554.adobeaemcloud.com/ui#/@formsinternal01/aem/universal-editor/canvas/author-p133911-e1313554.adobeaemcloud.com/content/forms/af/lovely/component-name.html

Before :
<img width="395" height="336" alt="image" src="https://github.com/user-attachments/assets/7bc2c3b1-ce40-4064-bb49-e902c7fc1f05" />

After : 
<img width="397" height="366" alt="image" src="https://github.com/user-attachments/assets/2ba59ecf-8c68-43ac-ac61-64792cec3ca4" />

Also Sorted the component list and renamed few components as per the suggestion from DOC team:
before :
<img width="201" height="808" alt="image" src="https://github.com/user-attachments/assets/ff3c57ca-e0fb-4680-87aa-218a5862c76a" />

After  :
<img width="211" height="814" alt="image" src="https://github.com/user-attachments/assets/a485833f-085f-4758-a8a5-a4a04410a4a3" />

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://edscomponentname--aem-boilerplate-forms--adobe-rnd.aem.live/
