### PR TITLE
Revert "Adding Component names to Property rail. (#122)"

### DIFF
--- a/blocks/form/_form.json
+++ b/blocks/form/_form.json
@@ -15,74 +15,23 @@
         }
       }
     },
+    {
+      "...": "./models/form-components/_*.json#/definitions"
+    },
     { 
       "...": "./components/accordion/_accordion.json#/definitions" 
-    },
-    {
-      "...": "./models/form-components/_recaptcha.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_checkbox-group.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_date-input.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_drop-down.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_email.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_file-input.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_button.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_fragment.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_image.json#/definitions"
     },
     { 
       "...": "./components/modal/_modal.json#/definitions" 
     },
-    {
-      "...": "./models/form-components/_number-input.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_panel.json#/definitions"
-    },
     { 
       "...": "./components/password/_password.json#/definitions" 
-    },
-    {
-      "...": "./models/form-components/_telephone-input.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_radio-group.json#/definitions"
     },
     { 
       "...": "./components/rating/_rating.json#/definitions" 
     },
-    {
-      "...": "./models/form-components/_reset-button.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_checkbox.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_text.json#/definitions"
-    },
-    {
-      "...": "./models/form-components/_submit-button.json#/definitions"
-    },
     { 
       "...": "./components/tnc/_tnc.json#/definitions" 
-    },
-    {
-      "...": "./models/form-components/_text-input.json#/definitions"
     },
     { 
       "...": "./components/wizard/_wizard.json#/definitions" 

--- a/blocks/form/components/accordion/_accordion.json
+++ b/blocks/form/components/accordion/_accordion.json
@@ -33,13 +33,6 @@
             "id": "accordion",
             "fields": [
                 {
-                    "component": "container",
-                    "name": "accordion_label",
-                    "label": "Accordion",
-                    "collapsible": false,
-                    "...": "../../models/form-common/_basic-input-fields.json"
-                },
-                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/components/password/_password.json
+++ b/blocks/form/components/password/_password.json
@@ -8,7 +8,7 @@
           "page": {
             "resourceType": "core/fd/components/form/textinput/v1/textinput",
             "template": {
-              "jcr:title": "Password Field",
+              "jcr:title": "Password",
               "fieldType": "text-input",
               "fd:viewType": "password"
             }
@@ -21,12 +21,6 @@
     {
       "id": "password",
       "fields": [
-        {
-          "component": "container",
-          "name": "password_field_label",
-          "label": "Password Field",
-          "collapsible": false
-        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/components/range/_range.json
+++ b/blocks/form/components/range/_range.json
@@ -24,12 +24,6 @@
         "id": "range",
         "fields": [
           {
-            "component": "container",
-            "name": "range_label",
-            "label": "Range",
-            "collapsible": false
-          },
-          {
             "component": "tab",
             "label": "Basic",
             "name": "basic"

--- a/blocks/form/components/rating/_rating.json
+++ b/blocks/form/components/rating/_rating.json
@@ -22,12 +22,6 @@
       "id": "rating",
       "fields": [
         {
-          "component": "container",
-          "name": "rating_label",
-          "label": "Rating",
-          "collapsible": false
-        },
-        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/components/tnc/_tnc.json
+++ b/blocks/form/components/tnc/_tnc.json
@@ -60,12 +60,6 @@
       "id": "tnc",
       "fields": [
         {
-          "component": "container",
-          "name": "tnc_label",
-          "label": "Terms and conditions",
-          "collapsible": false
-        },
-        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_button.json
+++ b/blocks/form/models/form-components/_button.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Form Button",
+      "title": "Button",
       "id": "form-button",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/button/v1/button",
             "template": {
-              "jcr:title": "Form Button",
+              "jcr:title": "Button",
               "fieldType": "button"
             }
           }
@@ -20,12 +20,6 @@
     {
       "id": "form-button",
       "fields": [
-        {
-          "component": "container",
-          "name": "button_label",
-          "label": "Form Button",
-          "collapsible": false
-        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_checkbox-group.json
+++ b/blocks/form/models/form-components/_checkbox-group.json
@@ -31,12 +31,6 @@
             "id": "checkbox-group",
             "fields": [
                 {
-                    "component": "container",
-                    "name": "checkbox_group_label",
-                    "label": "Checkbox Group",
-                    "collapsible": false
-                },
-                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_checkbox.json
+++ b/blocks/form/models/form-components/_checkbox.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Single Checkbox",
+            "title": "Checkbox",
             "id": "checkbox",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
                         "template": {
-                            "jcr:title": "Single Checkbox",
+                            "jcr:title": "Checkbox",
                             "fieldType": "checkbox",
                             "checkedValue": "on"
                         }
@@ -21,12 +21,6 @@
         {
             "id": "checkbox",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "checkbox_label",
-                    "label": "Single Checkbox",
-                    "collapsible": false
-                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_date-input.json
+++ b/blocks/form/models/form-components/_date-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Date Picker",
+            "title": "Date Input",
             "id": "date-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/datepicker/v1/datepicker",
                         "template": {
-                            "jcr:title": "Date Picker",
+                            "jcr:title": "Date Input",
                             "fieldType": "date-input"
                         }
                     }
@@ -20,12 +20,6 @@
         {
             "id": "date-input",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "date_picker_label",
-                    "label": "Date Picker",
-                    "collapsible": false
-                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_drop-down.json
+++ b/blocks/form/models/form-components/_drop-down.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Dropdown",
+      "title": "Dropdown List",
       "id": "drop-down",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/dropdown/v1/dropdown",
             "template": {
-              "jcr:title": "Drop Down",
+              "jcr:title": "Drop Down List",
               "fieldType": "drop-down",
               "enum": [
                 "0",
@@ -29,12 +29,6 @@
     {
       "id": "drop-down",
       "fields": [
-        {
-          "component": "container",
-          "name": "dropdown_label",
-          "label": "Dropdown",
-          "collapsible": false
-        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_email.json
+++ b/blocks/form/models/form-components/_email.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Email Field",
+            "title": "Email",
             "id": "email",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/emailinput/v1/emailinput",
                         "template": {
-                            "jcr:title": "Email Field",
+                            "jcr:title": "Email Input",
                             "fieldType": "email"
                         }
                     }
@@ -20,12 +20,6 @@
         {
             "id": "email",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "email_input_label",
-                    "label": "Email Field",
-                    "collapsible": false
-                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_file-input.json
+++ b/blocks/form/models/form-components/_file-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "File Upload",
+            "title": "File Attachment",
             "id": "file-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/fileinput/v2/fileinput",
                         "template": {
-                            "jcr:title": "File Upload",
+                            "jcr:title": "File Attachment",
                             "fieldType": "file-input",
                             "accept": [
                                 "audio/*",
@@ -30,12 +30,6 @@
         {
             "id": "file-input",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "file_upload_label",
-                    "label": "File Upload",
-                    "collapsible": false
-                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -8,7 +8,7 @@
                     "page": {
                         "resourceType": "core/fd/components/form/fragment/v1/fragment",
                         "template": {
-                            "jcr:title": "Form Fragment",
+                            "jcr:title": "Fragment",
                             "fieldType": "panel",
                             "minOccur": 1
                         }
@@ -21,12 +21,6 @@
         {
             "id": "form-fragment",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "form_fragment_label",
-                    "label": "Form Fragment",
-                    "collapsible": false
-                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_image.json
+++ b/blocks/form/models/form-components/_image.json
@@ -21,12 +21,6 @@
             "id": "form-image",
             "fields": [
                 {
-                    "component": "container",
-                    "name": "image_label",
-                    "label": "Image",
-                    "collapsible": false
-                },
-                {
                     "component": "text",
                     "name": "name",
                     "label": "Name",

--- a/blocks/form/models/form-components/_multiline-input.json
+++ b/blocks/form/models/form-components/_multiline-input.json
@@ -5,12 +5,6 @@
       "id": "multiline-input",
       "fields": [
         {
-          "component": "container",
-          "name": "text_area_label",
-          "label": "Text Area",
-          "collapsible": false
-        },
-        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_number-input.json
+++ b/blocks/form/models/form-components/_number-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Number Field",
+            "title": "Number Input",
             "id": "number-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/numberinput/v1/numberinput",
                         "template": {
-                            "jcr:title": "Number Field",
+                            "jcr:title": "Number Input",
                             "fieldType": "number-input"
                         }
                     }
@@ -20,12 +20,6 @@
         {
             "id": "number-input",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "number_field_label",
-                    "label": "Number Field",
-                    "collapsible": false
-                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_panel.json
+++ b/blocks/form/models/form-components/_panel.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Panel / Section",
+            "title": "Panel",
             "id": "panel",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
                         "template": {
-                            "jcr:title": "Panel / Section",
+                            "jcr:title": "Panel",
                             "fieldType": "panel",
                             "minOccur": 1
                         }
@@ -21,12 +21,6 @@
         {
             "id": "panel",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "panel_label",
-                    "label": "Panel / Section",
-                    "collapsible": false
-                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_radio-group.json
+++ b/blocks/form/models/form-components/_radio-group.json
@@ -30,12 +30,6 @@
             "id": "radio-group",
             "fields": [
                 {
-                    "component": "container",
-                    "name": "radio_group_label",
-                    "label": "Radio Group",
-                    "collapsible": false
-                },
-                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_recaptcha.json
+++ b/blocks/form/models/form-components/_recaptcha.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Captcha (Invisible reCAPTCHA)",
+            "title": "Captcha (Invisible)",
             "id": "captcha",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
                         "template": {
-                            "jcr:title": "Captcha (Invisible reCAPTCHA)",
+                            "jcr:title": "Captcha (Invisible)",
                             "fieldType": "captcha"
                         }
                     }
@@ -20,12 +20,6 @@
         {
             "id": "captcha",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "captcha_label",
-                    "label": "Captcha (Invisible reCAPTCHA)",
-                    "collapsible": false
-                },
                 {
                     "component": "text",
                     "name": "name",

--- a/blocks/form/models/form-components/_reset-button.json
+++ b/blocks/form/models/form-components/_reset-button.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Reset Form Button",
+      "title": "Reset",
       "id": "form-reset-button",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/actions/reset/v1/reset",
             "template": {
-              "jcr:title": "Reset Form Button",
+              "jcr:title": "Reset",
               "buttonType": "reset",
               "fieldType": "button"
             }
@@ -21,12 +21,6 @@
     {
       "id": "form-reset-button",
       "fields": [
-        {
-          "component": "container",
-          "name": "reset_button_label",
-          "label": "Reset Form Button",
-          "collapsible": false
-        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_submit-button.json
+++ b/blocks/form/models/form-components/_submit-button.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Submit Form Button",
+      "title": "Submit",
       "id": "form-submit-button",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/actions/submit/v1/submit",
             "template": {
-              "jcr:title": "Submit Form Button",
+              "jcr:title": "Submit",
               "buttonType": "submit",
               "fieldType": "button"
             }
@@ -21,12 +21,6 @@
     {
       "id": "form-submit-button",
       "fields": [
-        {
-          "component": "container",
-          "name": "submit_button_label",
-          "label": "Submit Form Button",
-          "collapsible": false
-        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_telephone-input.json
+++ b/blocks/form/models/form-components/_telephone-input.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Phone Number Field",
+      "title": "Telephone input",
       "id": "telephone-input",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
             "template": {
-              "jcr:title": "Phone Number Field",
+              "jcr:title": "Telephone Input",
               "fieldType": "text-input"
             }
           }
@@ -20,12 +20,6 @@
     {
       "id": "telephone-input",
       "fields": [
-        {
-          "component": "container",
-          "name": "phone_number_field_label",
-          "label": "Phone Number Field",
-          "collapsible": false
-        },
         {
           "component": "tab",
           "label": "Basic",

--- a/blocks/form/models/form-components/_text-input.json
+++ b/blocks/form/models/form-components/_text-input.json
@@ -1,14 +1,14 @@
 {
     "definitions": [
         {
-            "title": "Text Field",
+            "title": "Text Input",
             "id": "text-input",
             "plugins": {
                 "xwalk": {
                     "page": {
                         "resourceType": "core/fd/components/form/textinput/v1/textinput",
                         "template": {
-                            "jcr:title": "Text Field",
+                            "jcr:title": "Text Input",
                             "fieldType": "text-input"
                         }
                     }
@@ -20,12 +20,6 @@
         {
             "id": "text-input",
             "fields": [
-                {
-                    "component": "container",
-                    "name": "text_field_label",
-                    "label": "Text Field",
-                    "collapsible": false
-                },
                 {
                     "component": "tab",
                     "label": "Basic",

--- a/blocks/form/models/form-components/_text.json
+++ b/blocks/form/models/form-components/_text.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Static Text / Display Text",
+      "title": "Text",
       "id": "plain-text",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/fd/components/form/text/v1/text",
             "template": {
-              "jcr:title": "Static Text / Display Text",
+              "jcr:title": "Text",
               "fieldType": "plain-text",
               "textIsRich": true,
               "value": "Adaptive Form Text Component"
@@ -22,12 +22,6 @@
     {
       "id": "plain-text",
       "fields": [
-        {
-          "component": "container",
-          "name": "static_text_label",
-          "label": "Static Text / Display Text",
-          "collapsible": false
-        },
         {
           "component": "text",
           "name": "name",

--- a/component-definition.json
+++ b/component-definition.json
@@ -158,42 +158,15 @@
           }
         },
         {
-          "title": "Accordion",
-          "id": "form-accordion",
+          "title": "Button",
+          "id": "form-button",
           "plugins": {
             "xwalk": {
               "page": {
-                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
+                "resourceType": "core/fd/components/form/button/v1/button",
                 "template": {
-                  "jcr:title": "Accordion",
-                  "fieldType": "panel",
-                  "fd:viewType": "accordion",
-                  "minOccur": 1,
-                  "panel1": {
-                    "jcr:title": "Item 1",
-                    "fieldType": "panel",
-                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
-                  },
-                  "panel2": {
-                    "jcr:title": "Item 2",
-                    "fieldType": "panel",
-                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
-                  }
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Captcha (Invisible reCAPTCHA)",
-          "id": "captcha",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
-                "template": {
-                  "jcr:title": "Captcha (Invisible reCAPTCHA)",
-                  "fieldType": "captcha"
+                  "jcr:title": "Button",
+                  "fieldType": "button"
                 }
               }
             }
@@ -225,14 +198,30 @@
           }
         },
         {
-          "title": "Date Picker",
+          "title": "Checkbox",
+          "id": "checkbox",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
+                "template": {
+                  "jcr:title": "Checkbox",
+                  "fieldType": "checkbox",
+                  "checkedValue": "on"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Date Input",
           "id": "date-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/datepicker/v1/datepicker",
                 "template": {
-                  "jcr:title": "Date Picker",
+                  "jcr:title": "Date Input",
                   "fieldType": "date-input"
                 }
               }
@@ -240,14 +229,14 @@
           }
         },
         {
-          "title": "Dropdown",
+          "title": "Dropdown List",
           "id": "drop-down",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/dropdown/v1/dropdown",
                 "template": {
-                  "jcr:title": "Drop Down",
+                  "jcr:title": "Drop Down List",
                   "fieldType": "drop-down",
                   "enum": [
                     "0",
@@ -264,14 +253,14 @@
           }
         },
         {
-          "title": "Email Field",
+          "title": "Email",
           "id": "email",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/emailinput/v1/emailinput",
                 "template": {
-                  "jcr:title": "Email Field",
+                  "jcr:title": "Email Input",
                   "fieldType": "email"
                 }
               }
@@ -279,14 +268,14 @@
           }
         },
         {
-          "title": "File Upload",
+          "title": "File Attachment",
           "id": "file-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/fileinput/v2/fileinput",
                 "template": {
-                  "jcr:title": "File Upload",
+                  "jcr:title": "File Attachment",
                   "fieldType": "file-input",
                   "accept": [
                     "audio/*",
@@ -304,21 +293,6 @@
           }
         },
         {
-          "title": "Form Button",
-          "id": "form-button",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/button/v1/button",
-                "template": {
-                  "jcr:title": "Form Button",
-                  "fieldType": "button"
-                }
-              }
-            }
-          }
-        },
-        {
           "title": "Form Fragment",
           "id": "form-fragment",
           "plugins": {
@@ -326,7 +300,7 @@
               "page": {
                 "resourceType": "core/fd/components/form/fragment/v1/fragment",
                 "template": {
-                  "jcr:title": "Form Fragment",
+                  "jcr:title": "Fragment",
                   "fieldType": "panel",
                   "minOccur": 1
                 }
@@ -350,31 +324,14 @@
           }
         },
         {
-          "title": "Modal",
-          "id": "form-modal",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
-                "template": {
-                  "jcr:title": "Modal",
-                  "fieldType": "panel",
-                  "fd:viewType": "modal",
-                  "visible": false
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Number Field",
+          "title": "Number Input",
           "id": "number-input",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/numberinput/v1/numberinput",
                 "template": {
-                  "jcr:title": "Number Field",
+                  "jcr:title": "Number Input",
                   "fieldType": "number-input"
                 }
               }
@@ -382,47 +339,16 @@
           }
         },
         {
-          "title": "Panel / Section",
+          "title": "Panel",
           "id": "panel",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
                 "template": {
-                  "jcr:title": "Panel / Section",
+                  "jcr:title": "Panel",
                   "fieldType": "panel",
                   "minOccur": 1
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Password",
-          "id": "password",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/textinput/v1/textinput",
-                "template": {
-                  "jcr:title": "Password Field",
-                  "fieldType": "text-input",
-                  "fd:viewType": "password"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Phone Number Field",
-          "id": "telephone-input",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
-                "template": {
-                  "jcr:title": "Phone Number Field",
-                  "fieldType": "text-input"
                 }
               }
             }
@@ -453,6 +379,160 @@
           }
         },
         {
+          "title": "Captcha (Invisible)",
+          "id": "captcha",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/recaptcha/v1/recaptcha",
+                "template": {
+                  "jcr:title": "Captcha (Invisible)",
+                  "fieldType": "captcha"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Reset",
+          "id": "form-reset-button",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/actions/reset/v1/reset",
+                "template": {
+                  "jcr:title": "Reset",
+                  "buttonType": "reset",
+                  "fieldType": "button"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Submit",
+          "id": "form-submit-button",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/actions/submit/v1/submit",
+                "template": {
+                  "jcr:title": "Submit",
+                  "buttonType": "submit",
+                  "fieldType": "button"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Telephone input",
+          "id": "telephone-input",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/telephoneinput/v1/telephoneinput",
+                "template": {
+                  "jcr:title": "Telephone Input",
+                  "fieldType": "text-input"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Text Input",
+          "id": "text-input",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/textinput/v1/textinput",
+                "template": {
+                  "jcr:title": "Text Input",
+                  "fieldType": "text-input"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Text",
+          "id": "plain-text",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/text/v1/text",
+                "template": {
+                  "jcr:title": "Text",
+                  "fieldType": "plain-text",
+                  "textIsRich": true,
+                  "value": "Adaptive Form Text Component"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Accordion",
+          "id": "form-accordion",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
+                "template": {
+                  "jcr:title": "Accordion",
+                  "fieldType": "panel",
+                  "fd:viewType": "accordion",
+                  "minOccur": 1,
+                  "panel1": {
+                    "jcr:title": "Item 1",
+                    "fieldType": "panel",
+                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
+                  },
+                  "panel2": {
+                    "jcr:title": "Item 2",
+                    "fieldType": "panel",
+                    "sling:resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Modal",
+          "id": "form-modal",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/panelcontainer/v1/panelcontainer",
+                "template": {
+                  "jcr:title": "Modal",
+                  "fieldType": "panel",
+                  "fd:viewType": "modal",
+                  "visible": false
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Password",
+          "id": "password",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/fd/components/form/textinput/v1/textinput",
+                "template": {
+                  "jcr:title": "Password",
+                  "fieldType": "text-input",
+                  "fd:viewType": "password"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Rating",
           "id": "rating",
           "plugins": {
@@ -463,71 +543,6 @@
                   "jcr:title": "Rating",
                   "fieldType": "number-input",
                   "fd:viewType": "rating"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Reset Form Button",
-          "id": "form-reset-button",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/actions/reset/v1/reset",
-                "template": {
-                  "jcr:title": "Reset Form Button",
-                  "buttonType": "reset",
-                  "fieldType": "button"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Single Checkbox",
-          "id": "checkbox",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/checkbox/v1/checkbox",
-                "template": {
-                  "jcr:title": "Single Checkbox",
-                  "fieldType": "checkbox",
-                  "checkedValue": "on"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Static Text / Display Text",
-          "id": "plain-text",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/text/v1/text",
-                "template": {
-                  "jcr:title": "Static Text / Display Text",
-                  "fieldType": "plain-text",
-                  "textIsRich": true,
-                  "value": "Adaptive Form Text Component"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Submit Form Button",
-          "id": "form-submit-button",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/actions/submit/v1/submit",
-                "template": {
-                  "jcr:title": "Submit Form Button",
-                  "buttonType": "submit",
-                  "fieldType": "button"
                 }
               }
             }
@@ -584,21 +599,6 @@
                       "true"
                     ]
                   }
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Text Field",
-          "id": "text-input",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/fd/components/form/textinput/v1/textinput",
-                "template": {
-                  "jcr:title": "Text Field",
-                  "fieldType": "text-input"
                 }
               }
             }

--- a/component-models.json
+++ b/component-models.json
@@ -211,12 +211,6 @@
     "id": "form-button",
     "fields": [
       {
-        "component": "container",
-        "name": "button_label",
-        "label": "Form Button",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -332,12 +326,6 @@
   {
     "id": "checkbox-group",
     "fields": [
-      {
-        "component": "container",
-        "name": "checkbox_group_label",
-        "label": "Checkbox Group",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -579,12 +567,6 @@
     "id": "checkbox",
     "fields": [
       {
-        "component": "container",
-        "name": "checkbox_label",
-        "label": "Single Checkbox",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -801,12 +783,6 @@
   {
     "id": "date-input",
     "fields": [
-      {
-        "component": "container",
-        "name": "date_picker_label",
-        "label": "Date Picker",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -1052,12 +1028,6 @@
     "id": "drop-down",
     "fields": [
       {
-        "component": "container",
-        "name": "dropdown_label",
-        "label": "Dropdown",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1289,12 +1259,6 @@
     "id": "email",
     "fields": [
       {
-        "component": "container",
-        "name": "email_input_label",
-        "label": "Email Field",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1514,12 +1478,6 @@
     "id": "file-input",
     "fields": [
       {
-        "component": "container",
-        "name": "file_upload_label",
-        "label": "File Upload",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1722,12 +1680,6 @@
     "id": "form-fragment",
     "fields": [
       {
-        "component": "container",
-        "name": "form_fragment_label",
-        "label": "Form Fragment",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1924,12 +1876,6 @@
     "id": "form-image",
     "fields": [
       {
-        "component": "container",
-        "name": "image_label",
-        "label": "Image",
-        "collapsible": false
-      },
-      {
         "component": "text",
         "name": "name",
         "label": "Name",
@@ -2029,12 +1975,6 @@
   {
     "id": "multiline-input",
     "fields": [
-      {
-        "component": "container",
-        "name": "text_area_label",
-        "label": "Text Area",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -2260,12 +2200,6 @@
   {
     "id": "number-input",
     "fields": [
-      {
-        "component": "container",
-        "name": "number_field_label",
-        "label": "Number Field",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -2520,12 +2454,6 @@
   {
     "id": "panel",
     "fields": [
-      {
-        "component": "container",
-        "name": "panel_label",
-        "label": "Panel / Section",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -2799,12 +2727,6 @@
     "id": "radio-group",
     "fields": [
       {
-        "component": "container",
-        "name": "radio_group_label",
-        "label": "Radio Group",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -3044,12 +2966,6 @@
     "id": "captcha",
     "fields": [
       {
-        "component": "container",
-        "name": "captcha_label",
-        "label": "Captcha (Invisible reCAPTCHA)",
-        "collapsible": false
-      },
-      {
         "component": "text",
         "name": "name",
         "label": "Name",
@@ -3061,12 +2977,6 @@
   {
     "id": "form-reset-button",
     "fields": [
-      {
-        "component": "container",
-        "name": "reset_button_label",
-        "label": "Reset Form Button",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3184,12 +3094,6 @@
     "id": "form-submit-button",
     "fields": [
       {
-        "component": "container",
-        "name": "submit_button_label",
-        "label": "Submit Form Button",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -3305,12 +3209,6 @@
   {
     "id": "telephone-input",
     "fields": [
-      {
-        "component": "container",
-        "name": "phone_number_field_label",
-        "label": "Phone Number Field",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3516,12 +3414,6 @@
   {
     "id": "text-input",
     "fields": [
-      {
-        "component": "container",
-        "name": "text_field_label",
-        "label": "Text Field",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3748,12 +3640,6 @@
     "id": "plain-text",
     "fields": [
       {
-        "component": "container",
-        "name": "static_text_label",
-        "label": "Static Text / Display Text",
-        "collapsible": false
-      },
-      {
         "component": "text",
         "name": "name",
         "label": "Name",
@@ -3835,127 +3721,6 @@
   {
     "id": "accordion",
     "fields": [
-      {
-        "component": "container",
-        "name": "accordion_label",
-        "label": "Accordion",
-        "collapsible": false,
-        "fields": [
-          {
-            "component": "text",
-            "name": "name",
-            "label": "Name",
-            "valueType": "string",
-            "required": true,
-            "valueFormat": "regexp",
-            "validation": {
-              "regExp": "^[^$].*",
-              "customErrorMsg": "Name cannot start with $"
-            }
-          },
-          {
-            "component": "text",
-            "name": "jcr:title",
-            "label": "Title",
-            "valueType": "string"
-          },
-          {
-            "component": "boolean",
-            "name": "hideTitle",
-            "label": "Hide title",
-            "valueType": "boolean"
-          },
-          {
-            "component": "datasource-bindref",
-            "name": "dataRef",
-            "label": "Bind reference",
-            "valueType": "string"
-          },
-          {
-            "component": "boolean",
-            "name": "unboundFormElement",
-            "label": "Mark as Unbound Form Element",
-            "valueType": "boolean"
-          },
-          {
-            "component": "boolean",
-            "name": "visible",
-            "label": "Show Component",
-            "valueType": "boolean",
-            "value": true
-          },
-          {
-            "component": "boolean",
-            "name": "enabled",
-            "label": "Enable Component",
-            "valueType": "boolean",
-            "value": true
-          },
-          {
-            "component": "boolean",
-            "name": "readOnly",
-            "label": "Read-only",
-            "valueType": "boolean"
-          },
-          {
-            "component": "select",
-            "name": "colspan",
-            "label": "Column Span",
-            "valueType": "string",
-            "value": "12",
-            "options": [
-              {
-                "name": "1 column",
-                "value": "1"
-              },
-              {
-                "name": "2 column",
-                "value": "2"
-              },
-              {
-                "name": "3 column",
-                "value": "3"
-              },
-              {
-                "name": "4 column",
-                "value": "4"
-              },
-              {
-                "name": "5 column",
-                "value": "5"
-              },
-              {
-                "name": "6 column",
-                "value": "6"
-              },
-              {
-                "name": "7 column",
-                "value": "7"
-              },
-              {
-                "name": "8 column",
-                "value": "8"
-              },
-              {
-                "name": "9 column",
-                "value": "9"
-              },
-              {
-                "name": "10 column",
-                "value": "10"
-              },
-              {
-                "name": "11 column",
-                "value": "11"
-              },
-              {
-                "name": "12 column",
-                "value": "12"
-              }
-            ]
-          }
-        ]
-      },
       {
         "component": "tab",
         "label": "Basic",
@@ -4237,12 +4002,6 @@
     "id": "password",
     "fields": [
       {
-        "component": "container",
-        "name": "password_field_label",
-        "label": "Password Field",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4450,12 +4209,6 @@
     "id": "range",
     "fields": [
       {
-        "component": "container",
-        "name": "range_label",
-        "label": "Range",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4661,12 +4414,6 @@
     "id": "rating",
     "fields": [
       {
-        "component": "container",
-        "name": "rating_label",
-        "label": "Rating",
-        "collapsible": false
-      },
-      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4859,12 +4606,6 @@
   {
     "id": "tnc",
     "fields": [
-      {
-        "component": "container",
-        "name": "tnc_label",
-        "label": "Terms and conditions",
-        "collapsible": false
-      },
       {
         "component": "tab",
         "label": "Basic",


### PR DESCRIPTION
This reverts commit 996fe03485ceb2fae66281983a40273bc1e9d89e.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://revert-122-edscomponentname--aem-boilerplate-forms--adobe-rnd.aem.live/
