### PR TITLE
Set default path for custom functions in initAdaptiveForm

### DIFF
--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -401,7 +401,7 @@ async function initializeRuleEngineWorker(formDef, renderHTMLForm) {
 }
 
 export async function initAdaptiveForm(formDef, createForm) {
-  await registerCustomFunctions(formDef?.properties?.customFunctionsPath, window.hlx?.codeBasePath);
+  await registerCustomFunctions(formDef?.properties?.customFunctionsPath || '../functions.js', window.hlx?.codeBasePath);
   const response = await initializeRuleEngineWorker(formDef, createForm);
   return response?.form;
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://ravise5-patch-2--aem-boilerplate-forms--adobe-rnd.aem.live/
