### PR TITLE
Adding mobile responsiveness for fields, with colspan

### DIFF
--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -783,6 +783,12 @@ main div.form-wrapper {
     box-shadow: 0 4px 24px rgb(0 0 0 / 8%);
 }
 
+ /* Stack all form fields in a single column. [class*="col-"] overrides .col-1..col-12 (same specificity). */
+ main .form form .field-wrapper,
+ main .form form .field-wrapper[class*="col-"] {
+     grid-column: span 12;
+ }
+
 /* Responsive adjustments for mobile */
 @media (width <= 599px) {
     :root {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
issue : in using the WKND2.0 project for a demo and as part of it I'm also building a form into the UE but I'm experiencing an issue. As you can see i had to put some input fields on the same row, i did it by assigning 4 columns to each of them (since the container is 12 columns), and i would expect, when moving to mobile preview, these fields to end up in 1 column and eventually, also the wizard header to display better (this was the behavior with core components and page editor I think), but nothing happens.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://<branch>--aem-boilerplate-forms--adobe-rnd.aem.live/
