### PR TITLE
FORMS-20871: Status message not automatically announced @sunnym @vavarshn

### DIFF
--- a/blocks/form/submit.js
+++ b/blocks/form/submit.js
@@ -11,6 +11,7 @@ export function submitSuccess(e, form) {
     if (!thankYouMessage) {
       thankYouMessage = document.createElement('div');
       thankYouMessage.className = 'form-message success-message';
+      thankYouMessage.setAttribute('aria-live', 'assertive');
     }
     thankYouMessage.innerHTML = thankYouMsg || DEFAULT_THANK_YOU_MESSAGE;
     form.parentNode.insertBefore(thankYouMessage, form);
@@ -28,6 +29,7 @@ export function submitFailure(e, form) {
   if (!errorMessage) {
     errorMessage = document.createElement('div');
     errorMessage.className = 'form-message error-message';
+    errorMessage.setAttribute('role', 'alert');
   }
   errorMessage.innerHTML = 'Some error occured while submitting the form'; // TODO: translation
   form.prepend(errorMessage);

--- a/test/unit/fixtures/doc-based-submit/failed-submit.js
+++ b/test/unit/fixtures/doc-based-submit/failed-submit.js
@@ -46,6 +46,7 @@ export function expect(block) {
   assert.equal(scope.isDone(), true, 'submit call was not made');
   const el = block.querySelector('.form-message.error-message');
   assert.equal(el.textContent, 'Some error occured while submitting the form');
+  assert.equal(el.hasAttribute('role') && el.getAttribute('role') === 'alert', true);
 }
 
 export const opDelay = 200;

--- a/test/unit/fixtures/submit/failed-submit.js
+++ b/test/unit/fixtures/submit/failed-submit.js
@@ -39,6 +39,7 @@ export function expect(block) {
   assert.equal(scope.isDone(), true);
   const el = block.querySelector('.form-message.error-message');
   assert.equal(el.textContent, 'Some error occured while submitting the form');
+  assert.equal(el.hasAttribute('role') && el.getAttribute('role') === 'alert', true);
 }
 
 export const opDelay = 100;

--- a/test/unit/fixtures/submit/successful-submit-baseurl.js
+++ b/test/unit/fixtures/submit/successful-submit-baseurl.js
@@ -74,6 +74,7 @@ export function expect(block) {
   assert.equal(scope.isDone(), true, 'submit call was not made');
   const el = block.querySelector('.form-message.success-message');
   assert.equal(el.textContent, thankYouMessage);
+  assert.equal(el.hasAttribute('aria-live') && el.getAttribute('aria-live') === 'assertive', true);
 }
 
 export function after() {

--- a/test/unit/fixtures/submit/successful-submit.js
+++ b/test/unit/fixtures/submit/successful-submit.js
@@ -71,6 +71,7 @@ export function expect(block) {
   assert.equal(el.textContent, thankYouMessage);
   assert.equal(el.nextSibling.nodeName, 'FORM');
   assert.equal(el.parentElement.nodeName, 'DIV');
+  assert.equal(el.hasAttribute('aria-live') && el.getAttribute('aria-live') === 'assertive', true);
 }
 
 export const opDelay = 100;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
