### PR TITLE
fix: call panel model validate() in wizard to show field error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.worktrees/
 .hlx/*
 coverage/*
 logs/*

--- a/blocks/form/components/wizard/wizard.js
+++ b/blocks/form/components/wizard/wizard.js
@@ -1,4 +1,5 @@
 import { createButton } from '../../util.js';
+import { subscribe } from '../../rules/index.js';
 
 export class WizardLayout {
   inputFields = 'input,textarea,select';
@@ -50,6 +51,10 @@ export class WizardLayout {
     }, true);
 
     if (!isValid) {
+      // Trigger model-level validation so invalid events fire and error messages render.
+      // _fieldModel is set by the subscribe callback in wizardLayout; undefined for doc-based
+      // forms where the rule engine is not loaded (safe no-op via optional chaining).
+      container._fieldModel?.validate?.();
       container.querySelector(':invalid')?.focus();
     }
     return isValid;
@@ -180,8 +185,17 @@ export class WizardLayout {
 
 const layout = new WizardLayout();
 
-export default function wizardLayout(panel) {
+// eslint-disable-next-line no-unused-vars
+export default function wizardLayout(panel, fd, container, formId) {
   layout.applyLayout(panel);
+  // Cache each step panel's model on the DOM element so validateContainer can call
+  // model.validate(), which dispatches invalid events and triggers error message rendering.
+  // subscribe() is a no-op for doc-based forms (formModels[formId] never populated).
+  layout.getSteps(panel).forEach((step) => {
+    subscribe(step, formId, (_, stepModel) => {
+      step._fieldModel = stepModel;
+    });
+  });
   return panel;
 }
 

--- a/blocks/form/components/wizard/wizard.js
+++ b/blocks/form/components/wizard/wizard.js
@@ -54,6 +54,7 @@ export class WizardLayout {
       // Trigger model-level validation so invalid events fire and error messages render.
       // _fieldModel is set by the subscribe callback in wizardLayout; undefined for doc-based
       // forms where the rule engine is not loaded (safe no-op via optional chaining).
+      // eslint-disable-next-line no-underscore-dangle
       container._fieldModel?.validate?.();
       container.querySelector(':invalid')?.focus();
     }
@@ -193,6 +194,7 @@ export default function wizardLayout(panel, fd, container, formId) {
   // subscribe() is a no-op for doc-based forms (formModels[formId] never populated).
   layout.getSteps(panel).forEach((step) => {
     subscribe(step, formId, (_, stepModel) => {
+      // eslint-disable-next-line no-underscore-dangle
       step._fieldModel = stepModel;
     });
   });

--- a/test/unit/fixtures/dynamic/wizard-validate.js
+++ b/test/unit/fixtures/dynamic/wizard-validate.js
@@ -1,0 +1,88 @@
+import assert from 'assert';
+
+// A two-step wizard where step 1 has a required text field.
+// Clicking Next without filling step 1 should:
+//   1. Block navigation — step 1 stays current
+//   2. Show error message — .field-invalid + .field-description appear on the required field
+export const sample = {
+  id: 'wizard-validate-test-form',
+  fieldType: 'form',
+  title: 'Wizard Validation Test',
+  action: '/submit',
+  adaptiveform: '0.12.1',
+  metadata: { grammar: 'json-formula-1.0.0', version: '1.0.0' },
+  events: { 'custom:setProperty': ['$event.payload'] },
+  items: [
+    {
+      id: 'wizard-validate-panel',
+      fieldType: 'panel',
+      name: 'wizard1',
+      ':type': 'formsninja/components/adaptiveForm/wizard',
+      events: { 'custom:setProperty': ['$event.payload'] },
+      items: [
+        {
+          id: 'step1-validate-panel',
+          fieldType: 'panel',
+          name: 'step1',
+          label: { value: 'Step 1' },
+          events: { 'custom:setProperty': ['$event.payload'] },
+          ':type': 'formsninja/components/adaptiveForm/panelcontainer',
+          items: [
+            {
+              id: 'firstname-validate-field',
+              fieldType: 'text-input',
+              name: 'firstName',
+              type: 'string',
+              required: true,
+              label: { value: 'First Name' },
+              events: { 'custom:setProperty': ['$event.payload'] },
+              ':type': 'formsninja/components/adaptiveForm/textinput',
+            },
+          ],
+        },
+        {
+          id: 'step2-validate-panel',
+          fieldType: 'panel',
+          name: 'step2',
+          label: { value: 'Step 2' },
+          events: { 'custom:setProperty': ['$event.payload'] },
+          ':type': 'formsninja/components/adaptiveForm/panelcontainer',
+          items: [],
+        },
+      ],
+    },
+  ],
+};
+
+// Allow time for async model validation events to propagate through the rule engine
+export const opDelay = 100;
+
+export function op(block) {
+  const nextBtn = block.querySelector('.wizard .field-next');
+  assert.ok(nextBtn, 'Next button should exist');
+  nextBtn.click();
+}
+
+export function expect(block) {
+  // Navigation blocked — step 1 must still be the current step
+  const currentStep = block.querySelector('.current-wizard-step');
+  assert.ok(currentStep, 'A current step should still be active');
+  assert.equal(
+    currentStep.id,
+    'step1-validate-panel',
+    'Step 1 should remain current after clicking Next with an empty required field',
+  );
+
+  // Required field wrapper should carry field-invalid class
+  const firstNameWrapper = block.querySelector('#firstname-validate-field')?.closest('.field-wrapper');
+  assert.ok(firstNameWrapper, 'First name field wrapper should exist');
+  assert.ok(
+    firstNameWrapper.classList.contains('field-invalid'),
+    '.field-wrapper should have field-invalid class after model validation',
+  );
+
+  // Error message element must be present with non-empty text
+  const errorDesc = firstNameWrapper.querySelector('.field-description');
+  assert.ok(errorDesc, '.field-description error element should be rendered');
+  assert.ok(errorDesc.textContent.trim().length > 0, 'Error message should not be empty');
+}

--- a/test/unit/wizard.validate.test.js
+++ b/test/unit/wizard.validate.test.js
@@ -1,0 +1,71 @@
+/* eslint-env mocha */
+import assert from 'assert';
+import { WizardLayout } from '../../blocks/form/components/wizard/wizard.js';
+
+function makeContainer(id, { required = false, hidden = false } = {}) {
+  const container = document.createElement('fieldset');
+  container.id = id;
+  container.dataset.id = id;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'field-wrapper';
+  if (hidden) wrapper.dataset.visible = 'false';
+  const input = document.createElement('input');
+  input.type = 'text';
+  if (required) input.required = true;
+  input.value = '';
+  wrapper.appendChild(input);
+  container.appendChild(wrapper);
+  return container;
+}
+
+describe('WizardLayout.validateContainer — model bridge', () => {
+  let wizard;
+
+  beforeEach(() => {
+    wizard = new WizardLayout();
+  });
+
+  it('calls _fieldModel.validate() when DOM checkValidity() fails', () => {
+    const container = makeContainer('step1', { required: true });
+    let validateCalled = false;
+    container._fieldModel = { validate: () => { validateCalled = true; return Promise.resolve([]); } };
+
+    const result = wizard.validateContainer(container);
+
+    assert.strictEqual(result, false, 'should return false when DOM invalid');
+    assert.strictEqual(validateCalled, true, 'should call _fieldModel.validate()');
+  });
+
+  it('does not call _fieldModel.validate() when all visible fields are valid', () => {
+    const container = makeContainer('step1');
+    // input has no required attr — checkValidity() returns true
+    let validateCalled = false;
+    container._fieldModel = { validate: () => { validateCalled = true; return Promise.resolve([]); } };
+
+    const result = wizard.validateContainer(container);
+
+    assert.strictEqual(result, true, 'should return true when DOM valid');
+    assert.strictEqual(validateCalled, false, 'should not call validate() when fields pass');
+  });
+
+  it('does not crash when _fieldModel is undefined (doc-based forms)', () => {
+    const container = makeContainer('step1', { required: true });
+    // _fieldModel is intentionally not set — simulates doc-based form path
+
+    assert.doesNotThrow(() => {
+      const result = wizard.validateContainer(container);
+      assert.strictEqual(result, false, 'should still return false from DOM validation');
+    });
+  });
+
+  it('skips model validation when only hidden required fields are invalid', () => {
+    const container = makeContainer('step1', { required: true, hidden: true });
+    let validateCalled = false;
+    container._fieldModel = { validate: () => { validateCalled = true; return Promise.resolve([]); } };
+
+    const result = wizard.validateContainer(container);
+
+    assert.strictEqual(result, true, 'hidden required fields should not block navigation');
+    assert.strictEqual(validateCalled, false, 'should not call validate() when only hidden fields fail');
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause:** `validateContainer` in `wizard.js` only used browser-native `checkValidity()` which detects invalidity (focus redirects correctly) but never calls the AEM Forms model's `validate()`. Without model validation, no `invalid` events fire and view components never render error messages.
- **Fix:** Cache each step's panel model on its DOM element via the `subscribe()` pattern (same approach as `modal.js` and `repeat.js`), then call `container._fieldModel?.validate?.()` when DOM validation fails. This dispatches `invalid` events on all required children → view renders error messages.
- **Doc-based safety:** `formModels[formId]` is never populated for doc-based forms → subscribe callback never fires → `_fieldModel` stays `undefined` → `?.validate?.()` is a safe no-op.

## Test plan

- [x] Unit tests: `test/unit/wizard.validate.test.js` — 4 cases covering model bridge (called on invalid, not called when valid, no crash when undefined for doc-based, hidden fields skipped)
- [x] Integration fixture: `test/unit/fixtures/dynamic/wizard-validate.js` — two-step wizard, step 1 has required field, clicks Next and asserts navigation blocked + `.field-invalid` class + `.field-description` error message rendered
- [x] Full unit suite passes (254 tests, 0 failures)
- [x] Lint passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)