### PR TITLE
feat(FORMS-24975): lazy panel rendering (opt-in)

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -276,7 +276,15 @@ function renderField(fd) {
   return field;
 }
 
-export async function generateFormRendition(panel, container, formId, getItems = (p) => p?.items) {
+export async function generateFormRendition(
+  panel,
+  container,
+  formId,
+  getItems = (p) => p?.items,
+  options = {},
+) {
+  const { lazyPanels, lazyComponents } = options;
+  const activeChildId = panel.activeChild?.id ?? panel.activeChild;
   const items = getItems(panel) || [];
   const promises = items.map(async (field) => {
     field.value = field.value ?? '';
@@ -293,10 +301,27 @@ export async function generateFormRendition(panel, container, formId, getItems =
     }
     colSpanDecorator(field, element);
     if (field?.fieldType === 'panel') {
-      await generateFormRendition(field, element, formId, getItems);
+      // Defer non-active wizard panels and initially-hidden panels — render wrapper only.
+      if (lazyPanels && (
+        (activeChildId != null && field.id !== activeChildId)
+        || field.visible === false
+      )) {
+        lazyPanels.set(field.id, { fieldData: field, formId, getItems });
+        return element;
+      }
+      await generateFormRendition(field, element, formId, getItems, options);
       return element;
     }
-    await componentDecorator(element, field, container, formId);
+    // Defer component JS/CSS for initially-hidden fields — DOM wrapper is still appended so
+    // fieldChanged events can find the element; decorator runs when the field becomes visible.
+    if (field.visible === false && lazyComponents && field[':type'] !== 'analytics') {
+      lazyComponents.set(field.id, {
+        thunk: () => componentDecorator(element, field, container, formId),
+        qualifiedName: field.qualifiedName,
+      });
+    } else {
+      await componentDecorator(element, field, container, formId);
+    }
     return element;
   });
 
@@ -343,7 +368,26 @@ export async function createForm(formDef, data, source = 'aem') {
     form.className = formDef.appliedCssClassNames;
   }
   const formId = extractIdFromUrl(formPath); // formDef.id returns $form after getState()
-  await generateFormRendition(formDef, form, formId);
+  // Lazy rendering is opt-in via formDef.properties.lazyRendering = true. When enabled,
+  // non-active wizard panels and visible=false fields are deferred — wrappers are still
+  // appended (so fieldChanged events can find them) but decorators/children run only when
+  // the field/panel becomes active or visible.
+  const lazyEnabled = formDef?.properties?.lazyRendering === true;
+  const lazyPanels = lazyEnabled ? new Map() : undefined;
+  const lazyComponents = lazyEnabled ? new Map() : undefined;
+  await generateFormRendition(
+    formDef,
+    form,
+    formId,
+    undefined,
+    lazyEnabled ? { lazyPanels, lazyComponents } : {},
+  );
+  if (lazyEnabled) {
+    /* eslint-disable no-underscore-dangle */
+    form._lazyPanels = lazyPanels;
+    form._lazyComponents = lazyComponents;
+    /* eslint-enable no-underscore-dangle */
+  }
 
   let captcha;
   if (captchaField) {

--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -51,7 +51,17 @@ function compare(fieldVal, htmlVal, type) {
   return fieldVal === htmlVal;
 }
 
-function handleActiveChild(id, form) {
+// Returns the live model state for a panel after rules have run — used instead of
+// stale init-time fieldData when rendering lazily deferred panels.
+function getLivePanelState(panelId, form) {
+  const liveModel = formModels[form.dataset?.id];
+  if (!liveModel) return null;
+  let livePanel = null;
+  liveModel.visit((f) => { if (f.id === panelId) livePanel = f; });
+  return livePanel ? livePanel.getState(true) : null;
+}
+
+function handleActiveChild(id, form, generateFormRendition) {
   form.querySelectorAll('[data-active="true"]').forEach((ele) => ele.removeAttribute('data-active'));
   const field = form.querySelector(`#${id}`);
   if (field) {
@@ -62,6 +72,29 @@ function handleActiveChild(id, form) {
       field.scrollIntoView({ behavior: 'smooth' });
     }
   }
+  // If the newly active wizard panel was lazily deferred, render it now.
+  /* eslint-disable no-underscore-dangle */
+  if (generateFormRendition && form._lazyPanels?.has(id)) {
+    const { fieldData, formId, getItems } = form._lazyPanels.get(id);
+    form._lazyPanels.delete(id);
+    const panelEl = form.querySelector(`#${id}`);
+    if (panelEl) {
+      const renderData = getLivePanelState(id, form) || fieldData;
+      const promise = generateFormRendition(
+        renderData,
+        panelEl,
+        formId,
+        getItems,
+        { lazyComponents: form._lazyComponents },
+      );
+      if (fieldData.qualifiedName) {
+        renderPromises[fieldData.qualifiedName] = promise;
+        promise.then(() => { delete renderPromises[fieldData.qualifiedName]; });
+      }
+      promise.then(() => handleActiveChild(id, form, null));
+    }
+  }
+  /* eslint-enable no-underscore-dangle */
 }
 
 export async function fieldChanged(payload, form, generateFormRendition) {
@@ -161,7 +194,35 @@ export async function fieldChanged(payload, form, generateFormRendition) {
           field.value = valueToSet;
         }
         break;
-      case 'visible':
+      case 'visible': {
+        // Skip no-op mutation — prevents forced reflow when value is already set.
+        if (String(fieldWrapper.dataset.visible) === String(currentValue)) break;
+        /* eslint-disable no-underscore-dangle */
+        // Lazy component: run decorator first, show only after it resolves — prevents CLS.
+        if (currentValue === true && fieldType !== 'panel' && form._lazyComponents?.has(id)) {
+          if (!formModels[form.dataset?.id]) {
+            // Rule engine not ready yet — queue for reconciliation in loadRuleEngine.
+            form._pendingLazyComponents = form._pendingLazyComponents || new Set();
+            form._pendingLazyComponents.add(id);
+          } else {
+            const { thunk, qualifiedName: qn } = form._lazyComponents.get(id);
+            form._lazyComponents.delete(id);
+            const promise = thunk();
+            const setVisible = () => { fieldWrapper.dataset.visible = 'true'; };
+            if (qn) {
+              renderPromises[qn] = promise;
+              promise.then(() => { delete renderPromises[qn]; setVisible(); });
+            } else {
+              promise.then(setVisible);
+            }
+          }
+          break;
+        }
+        // Lazy panel already pre-rendered in loadRuleEngine — wait before showing (prevents CLS).
+        if (currentValue === true && fieldType === 'panel' && form._preRenderPromises?.has(id)) {
+          form._preRenderPromises.get(id).then(() => { fieldWrapper.dataset.visible = 'true'; });
+          break;
+        }
         fieldWrapper.dataset.visible = currentValue;
         if (fieldType === 'panel' && fieldWrapper.querySelector('dialog')) {
           const dialog = fieldWrapper.querySelector('dialog');
@@ -169,7 +230,31 @@ export async function fieldChanged(payload, form, generateFormRendition) {
             dialog.close(); // close triggers the event listener that removes the dialog overlay
           }
         }
+        // Lazy panel not yet pre-rendered: render now, or queue if model not ready yet.
+        if (currentValue === true && fieldType === 'panel' && generateFormRendition && form._lazyPanels?.has(id)) {
+          const liveState = getLivePanelState(id, form);
+          if (!liveState) {
+            form._pendingLazyRenders = form._pendingLazyRenders || new Set();
+            form._pendingLazyRenders.add(id);
+          } else {
+            const { fieldData, formId: storedFormId, getItems } = form._lazyPanels.get(id);
+            form._lazyPanels.delete(id);
+            const promise = generateFormRendition(
+              liveState,
+              field,
+              storedFormId,
+              getItems,
+              { lazyComponents: form._lazyComponents },
+            );
+            if (fieldData.qualifiedName) {
+              renderPromises[fieldData.qualifiedName] = promise;
+              promise.then(() => { delete renderPromises[fieldData.qualifiedName]; });
+            }
+          }
+        }
+        /* eslint-enable no-underscore-dangle */
         break;
+      }
       case 'enabled':
         // If checkboxgroup/radiogroup/drop-down is readOnly then it should remain disabled.
         if (fieldType === 'radio-group' || fieldType === 'checkbox-group') {
@@ -243,7 +328,7 @@ export async function fieldChanged(payload, form, generateFormRendition) {
           renderPromises[currentValue?.qualifiedName] = promise;
         }
         break;
-      case 'activeChild': handleActiveChild(activeChild, form);
+      case 'activeChild': handleActiveChild(activeChild, form, generateFormRendition);
         break;
       case 'valid':
         if (currentValue === true) {
@@ -274,12 +359,12 @@ export async function fieldChanged(payload, form, generateFormRendition) {
   });
 }
 
-function formChanged(payload, form) {
+function formChanged(payload, form, generateFormRendition) {
   const { changes } = payload;
   changes.forEach((change) => {
     const { propertyName, currentValue } = change;
     switch (propertyName) {
-      case 'activeChild': handleActiveChild(currentValue?.id, form);
+      case 'activeChild': handleActiveChild(currentValue?.id, form, generateFormRendition);
         break;
       default:
         break;
@@ -292,7 +377,7 @@ function handleRuleEngineEvent(e, form, generateFormRendition) {
   if (type === 'fieldChanged') {
     fieldChanged(payload, form, generateFormRendition);
   } else if (type === 'change') {
-    formChanged(payload, form);
+    formChanged(payload, form, generateFormRendition);
   } else if (type === 'submitSuccess') {
     submitSuccess(e, form);
   } else if (type === 'submitFailure') {
@@ -394,6 +479,90 @@ export async function loadRuleEngine(formDef, htmlForm, captcha, genFormRenditio
   const form = ruleEngine.restoreFormInstance(formDef, data, { logLevel: LOG_LEVEL });
   window.myForm = form;
   formModels[htmlForm.dataset?.id] = form;
+  /* eslint-disable no-underscore-dangle */
+  // Pre-render lazy panels that are visible=true in the live model — prevents CLS on restore.
+  if (htmlForm._lazyPanels?.size) {
+    htmlForm._preRenderPromises = new Map();
+    htmlForm._lazyPanels.forEach(({ fieldData, formId, getItems }, id) => {
+      const liveState = getLivePanelState(id, htmlForm);
+      if (liveState && liveState.visible === true) {
+        const panelEl = htmlForm.querySelector(`#${id}`);
+        if (panelEl) {
+          htmlForm._lazyPanels.delete(id);
+          const promise = genFormRendition(
+            liveState,
+            panelEl,
+            formId,
+            getItems,
+            { lazyComponents: htmlForm._lazyComponents },
+          );
+          htmlForm._preRenderPromises.set(id, promise);
+          promise.then(() => htmlForm._preRenderPromises?.delete(id));
+          if (fieldData.qualifiedName) {
+            renderPromises[fieldData.qualifiedName] = promise;
+            promise.then(() => { delete renderPromises[fieldData.qualifiedName]; });
+          }
+        }
+      }
+    });
+  }
+  // Flush panels queued by case 'visible' before the model was ready.
+  if (htmlForm._pendingLazyRenders?.size) {
+    htmlForm._pendingLazyRenders.forEach((id) => {
+      if (!htmlForm._lazyPanels?.has(id)) return;
+      const { fieldData, formId, getItems } = htmlForm._lazyPanels.get(id);
+      const panelEl = htmlForm.querySelector(`#${id}`);
+      if (!panelEl) return;
+      const liveState = getLivePanelState(id, htmlForm);
+      htmlForm._lazyPanels.delete(id);
+      const promise = genFormRendition(
+        liveState || fieldData,
+        panelEl,
+        formId,
+        getItems,
+        { lazyComponents: htmlForm._lazyComponents },
+      );
+      if (fieldData.qualifiedName) {
+        renderPromises[fieldData.qualifiedName] = promise;
+        promise.then(() => { delete renderPromises[fieldData.qualifiedName]; });
+      }
+    });
+    htmlForm._pendingLazyRenders.clear();
+  }
+  // Run thunks for lazy components that are visible=true in the live model.
+  if (htmlForm._lazyComponents?.size) {
+    htmlForm._lazyComponents.forEach(({ thunk, qualifiedName: qn }, id) => {
+      const liveField = formModels[htmlForm.dataset?.id]?.getElement(id);
+      if (liveField && liveField.visible === true) {
+        htmlForm._lazyComponents.delete(id);
+        const promise = thunk();
+        if (qn) {
+          renderPromises[qn] = promise;
+          promise.then(() => { delete renderPromises[qn]; });
+        }
+      }
+    });
+  }
+  // Flush components queued by case 'visible' before the model was ready.
+  if (htmlForm._pendingLazyComponents?.size) {
+    htmlForm._pendingLazyComponents.forEach((id) => {
+      if (!htmlForm._lazyComponents?.has(id)) return;
+      const liveField = formModels[htmlForm.dataset?.id]?.getElement(id);
+      const fieldWrapper = htmlForm.querySelector(`#${id}`)?.closest('.field-wrapper');
+      const { thunk, qualifiedName: qn } = htmlForm._lazyComponents.get(id);
+      htmlForm._lazyComponents.delete(id);
+      const promise = thunk();
+      const setVisible = () => { if (fieldWrapper) fieldWrapper.dataset.visible = 'true'; };
+      if (qn) {
+        renderPromises[qn] = promise;
+        promise.then(() => { delete renderPromises[qn]; if (liveField?.visible) setVisible(); });
+      } else {
+        promise.then(() => { if (liveField?.visible) setVisible(); });
+      }
+    });
+    htmlForm._pendingLazyComponents.clear();
+  }
+  /* eslint-enable no-underscore-dangle */
   const subscriptions = formSubscriptions[htmlForm.dataset?.id];
   form.subscribe((e) => {
     handleRuleEngineEvent(e, htmlForm, genFormRendition);


### PR DESCRIPTION
## Summary

Adds opt-in lazy rendering for adaptive forms. When enabled, defers initial rendering of inactive wizard panels, hidden panels, and hidden non-panel componentDecorators — wrappers are still appended so `fieldChanged` events resolve them, but children/decorators run only when the field becomes active or visible.

**Opt-in** via `formDef.properties.lazyRendering = true`. Existing forms and tests are unchanged when the flag is absent.

Ported from `forms-engine` commit `d8b6ff4f` (HDFC fork) — adapted for the public boilerplate:
- No `ruleEngine.js` re-export shim; logic stays in `rules/index.js` (the boilerplate's existing convention).
- `RuleEngineWorker.js` not touched — the boilerplate's worker already implements the property-sync (`applyFieldChanges`/`applyLiveFormChange`) protocol the source commit was adding to a less-evolved worker.
- `subscribe` not touched — already fires immediately on registered `formModels`.
- Opt-in gating added because the boilerplate's `modal` / `file-attachment-advance` / `dynamic-file-attachment*` unit tests assert the fully-decorated markup for `visible: false` fields; unconditional lazy would break them.

## Changes

**`blocks/form/form.js`**
- `generateFormRendition` accepts `options = { lazyPanels, lazyComponents }`. Non-active wizard panels and `visible: false` panels are recorded in `lazyPanels` (children skipped). `visible: false` non-panel fields (excluding `:type === 'analytics'`) have their `componentDecorator` stored as a thunk in `lazyComponents`.
- `createForm` reads `formDef.properties.lazyRendering`; if `true`, creates the Maps and attaches them to `form._lazyPanels` / `form._lazyComponents`.

**`blocks/form/rules/index.js`**
- New `getLivePanelState(panelId, form)` — walks the live model so deferred panels render with post-rules state, not stale init-time fieldData.
- `handleActiveChild` accepts `generateFormRendition`; if the activated wizard tab is a deferred panel, pops from `_lazyPanels`, renders with live state, tracks via `renderPromises`, then recurses to re-apply focus/active markers.
- `case 'visible'` branches: dedup no-op guard; lazy component → run thunk, set `data-visible=true` only after it resolves (prevents CLS); panel with in-flight `_preRenderPromises` → await before showing; deferred panel with live state → render now (or queue if model not yet ready).
- `loadRuleEngine`: pre-renders lazy panels live-visible (storing in-flight promises in `_preRenderPromises`); flushes `_pendingLazyRenders`; runs thunks for components live-visible; flushes `_pendingLazyComponents`.
- `formChanged` and `handleRuleEngineEvent` pass `generateFormRendition` through.

## How to opt in

```json
{
  "properties": {
    "lazyRendering": true
  }
}
```

## Test plan

- [x] `npm run lint` — 0 errors (15 pre-existing warnings unchanged)
- [x] `npm run test:unit` — 249 passing / 1 pending / 0 failing
- [x] `npm run coverage:unit` — exit 0; All files 82.16% / 82.77% / 88.05% / 82.16%
- [ ] Manual: wizard form with `lazyRendering: true` — inactive tabs render only on activation
- [ ] Manual: form with `visible: false` panel that toggles via a rule — panel renders on visibility flip
- [ ] Manual: form with `visible: false` non-panel field that toggles via a rule — decorator runs on visibility flip
- [ ] Manual: repeatable panel regression check
- [ ] Manual: form without `lazyRendering` property — byte-identical behavior to before

Supersedes #204 (which was raised from the fork by mistake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)