### PR TITLE
feat: add fieldType and fd:viewType as hidden dialog fields to all ED…

### DIFF
--- a/blocks/form/_form.json
+++ b/blocks/form/_form.json
@@ -42,6 +42,11 @@
       "id": "form",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "form"
+        },
+        {
           "component": "container",
           "name": "basic",
           "label": "Use the Edit Form Properties extension to configure Adaptive Form properties, including Submit Action, Prefill, and Thank-You options.",

--- a/blocks/form/components/accordion/_accordion.json
+++ b/blocks/form/components/accordion/_accordion.json
@@ -33,6 +33,16 @@
             "id": "accordion",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "panel"
+                },
+                {
+                    "component": "hidden",
+                    "name": "fd:viewType",
+                    "default": "accordion"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/components/modal/_modal.json
+++ b/blocks/form/components/modal/_modal.json
@@ -23,6 +23,16 @@
             "id": "modal",
             "fields": [
               {
+                "component": "hidden",
+                "name": "fieldType",
+                "default": "panel"
+              },
+              {
+                "component": "hidden",
+                "name": "fd:viewType",
+                "default": "modal"
+              },
+              {
                 "component": "tab",
                 "label": "Basic",
                 "name": "basic"

--- a/blocks/form/components/password/_password.json
+++ b/blocks/form/components/password/_password.json
@@ -22,6 +22,16 @@
       "id": "password",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "text-input"
+        },
+        {
+          "component": "hidden",
+          "name": "fd:viewType",
+          "default": "password"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/components/range/_range.json
+++ b/blocks/form/components/range/_range.json
@@ -24,6 +24,16 @@
         "id": "range",
         "fields": [
           {
+            "component": "hidden",
+            "name": "fieldType",
+            "default": "number-input"
+          },
+          {
+            "component": "hidden",
+            "name": "fd:viewType",
+            "default": "range"
+          },
+          {
             "component": "tab",
             "label": "Basic",
             "name": "basic"

--- a/blocks/form/components/rating/_rating.json
+++ b/blocks/form/components/rating/_rating.json
@@ -22,6 +22,16 @@
       "id": "rating",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "number-input"
+        },
+        {
+          "component": "hidden",
+          "name": "fd:viewType",
+          "default": "rating"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/components/tnc/_tnc.json
+++ b/blocks/form/components/tnc/_tnc.json
@@ -60,6 +60,16 @@
       "id": "tnc",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "panel"
+        },
+        {
+          "component": "hidden",
+          "name": "fd:viewType",
+          "default": "tnc"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/components/wizard/_wizard.json
+++ b/blocks/form/components/wizard/_wizard.json
@@ -33,6 +33,16 @@
       "id": "wizard",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "panel"
+        },
+        {
+          "component": "hidden",
+          "name": "fd:viewType",
+          "default": "wizard"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_button.json
+++ b/blocks/form/models/form-components/_button.json
@@ -21,6 +21,11 @@
       "id": "form-button",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "button"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_checkbox-group.json
+++ b/blocks/form/models/form-components/_checkbox-group.json
@@ -31,6 +31,11 @@
             "id": "checkbox-group",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "checkbox-group"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_checkbox.json
+++ b/blocks/form/models/form-components/_checkbox.json
@@ -22,6 +22,11 @@
             "id": "checkbox",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "checkbox"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_date-input.json
+++ b/blocks/form/models/form-components/_date-input.json
@@ -21,6 +21,11 @@
             "id": "date-input",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "date-input"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_drop-down.json
+++ b/blocks/form/models/form-components/_drop-down.json
@@ -30,6 +30,11 @@
       "id": "drop-down",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "drop-down"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_email.json
+++ b/blocks/form/models/form-components/_email.json
@@ -21,6 +21,11 @@
             "id": "email",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "email"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_file-input.json
+++ b/blocks/form/models/form-components/_file-input.json
@@ -31,6 +31,11 @@
             "id": "file-input",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "file-input"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_fragment.json
+++ b/blocks/form/models/form-components/_fragment.json
@@ -22,6 +22,11 @@
             "id": "form-fragment",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "panel"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_image.json
+++ b/blocks/form/models/form-components/_image.json
@@ -21,6 +21,11 @@
             "id": "form-image",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "image"
+                },
+                {
                     "component": "text",
                     "name": "name",
                     "label": "Name",

--- a/blocks/form/models/form-components/_number-input.json
+++ b/blocks/form/models/form-components/_number-input.json
@@ -21,6 +21,11 @@
             "id": "number-input",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "number-input"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_panel.json
+++ b/blocks/form/models/form-components/_panel.json
@@ -22,6 +22,11 @@
             "id": "panel",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "panel"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_radio-group.json
+++ b/blocks/form/models/form-components/_radio-group.json
@@ -30,6 +30,11 @@
             "id": "radio-group",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "radio-group"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_recaptcha.json
+++ b/blocks/form/models/form-components/_recaptcha.json
@@ -21,6 +21,11 @@
             "id": "captcha",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "captcha"
+                },
+                {
                     "component": "text",
                     "name": "name",
                     "label": "Name",

--- a/blocks/form/models/form-components/_reset-button.json
+++ b/blocks/form/models/form-components/_reset-button.json
@@ -22,6 +22,11 @@
       "id": "form-reset-button",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "button"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_submit-button.json
+++ b/blocks/form/models/form-components/_submit-button.json
@@ -22,6 +22,11 @@
       "id": "form-submit-button",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "button"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_telephone-input.json
+++ b/blocks/form/models/form-components/_telephone-input.json
@@ -21,6 +21,11 @@
       "id": "telephone-input",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "text-input"
+        },
+        {
           "component": "tab",
           "label": "Basic",
           "name": "basic"

--- a/blocks/form/models/form-components/_text-input.json
+++ b/blocks/form/models/form-components/_text-input.json
@@ -21,6 +21,11 @@
             "id": "text-input",
             "fields": [
                 {
+                    "component": "hidden",
+                    "name": "fieldType",
+                    "default": "text-input"
+                },
+                {
                     "component": "tab",
                     "label": "Basic",
                     "name": "basic"

--- a/blocks/form/models/form-components/_text.json
+++ b/blocks/form/models/form-components/_text.json
@@ -23,6 +23,11 @@
       "id": "plain-text",
       "fields": [
         {
+          "component": "hidden",
+          "name": "fieldType",
+          "default": "plain-text"
+        },
+        {
           "component": "text",
           "name": "name",
           "label": "Name",

--- a/component-models.json
+++ b/component-models.json
@@ -198,6 +198,11 @@
     "id": "form",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "form"
+      },
+      {
         "component": "container",
         "name": "basic",
         "label": "Use the Edit Form Properties extension to configure Adaptive Form properties, including Submit Action, Prefill, and Thank-You options.",
@@ -223,6 +228,11 @@
   {
     "id": "form-button",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "button"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -339,6 +349,11 @@
   {
     "id": "checkbox-group",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "checkbox-group"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -580,6 +595,11 @@
     "id": "checkbox",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "checkbox"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -796,6 +816,11 @@
   {
     "id": "date-input",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "date-input"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -1041,6 +1066,11 @@
     "id": "drop-down",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "drop-down"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1272,6 +1302,11 @@
     "id": "email",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "email"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1491,6 +1526,11 @@
     "id": "file-input",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "file-input"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1693,6 +1733,11 @@
     "id": "form-fragment",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "panel"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -1888,6 +1933,11 @@
   {
     "id": "form-image",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "image"
+      },
       {
         "component": "text",
         "name": "name",
@@ -2214,6 +2264,11 @@
     "id": "number-input",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "number-input"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -2467,6 +2522,11 @@
   {
     "id": "panel",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "panel"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -2740,6 +2800,11 @@
     "id": "radio-group",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "radio-group"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -2979,6 +3044,11 @@
     "id": "captcha",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "captcha"
+      },
+      {
         "component": "text",
         "name": "name",
         "label": "Name",
@@ -2990,6 +3060,11 @@
   {
     "id": "form-reset-button",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "button"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3107,6 +3182,11 @@
     "id": "form-submit-button",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "button"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -3222,6 +3302,11 @@
   {
     "id": "telephone-input",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "text-input"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3427,6 +3512,11 @@
   {
     "id": "text-input",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "text-input"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3653,6 +3743,11 @@
     "id": "plain-text",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "plain-text"
+      },
+      {
         "component": "text",
         "name": "name",
         "label": "Name",
@@ -3734,6 +3829,16 @@
   {
     "id": "accordion",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "panel"
+      },
+      {
+        "component": "hidden",
+        "name": "fd:viewType",
+        "default": "accordion"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -3875,6 +3980,16 @@
     "id": "modal",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "panel"
+      },
+      {
+        "component": "hidden",
+        "name": "fd:viewType",
+        "default": "modal"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4014,6 +4129,16 @@
   {
     "id": "password",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "text-input"
+      },
+      {
+        "component": "hidden",
+        "name": "fd:viewType",
+        "default": "password"
+      },
       {
         "component": "tab",
         "label": "Basic",
@@ -4222,6 +4347,16 @@
     "id": "range",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "number-input"
+      },
+      {
+        "component": "hidden",
+        "name": "fd:viewType",
+        "default": "range"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4427,6 +4562,16 @@
     "id": "rating",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "number-input"
+      },
+      {
+        "component": "hidden",
+        "name": "fd:viewType",
+        "default": "rating"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4620,6 +4765,16 @@
     "id": "tnc",
     "fields": [
       {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "panel"
+      },
+      {
+        "component": "hidden",
+        "name": "fd:viewType",
+        "default": "tnc"
+      },
+      {
         "component": "tab",
         "label": "Basic",
         "name": "basic"
@@ -4765,6 +4920,16 @@
   {
     "id": "wizard",
     "fields": [
+      {
+        "component": "hidden",
+        "name": "fieldType",
+        "default": "panel"
+      },
+      {
+        "component": "hidden",
+        "name": "fd:viewType",
+        "default": "wizard"
+      },
       {
         "component": "tab",
         "label": "Basic",


### PR DESCRIPTION
Surfaces `fieldType` and `fd:viewType` from each component's xwalk template as explicit hidden fields in the model dialog, so the Content API's `/content/definition` endpoint includes them without requiring code changes in the transformer. Fixes SITES-44191.

Relates to: https://jira.corp.adobe.com/browse/SITES-44191

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/component-models.json
- After: https://main--eds-forms-perf--dmaurya929.aem.page/component-models.json