### PR TITLE
fix: buffer field changes that arrive during worker restore

### DIFF
--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -433,7 +433,7 @@ export async function loadRuleEngine(formDef, htmlForm, captcha, genFormRenditio
   form.dispatch(new CustomEvent('formViewInitialized'));
 }
 
-async function initializeRuleEngineWorker(formDef, renderHTMLForm) {
+export async function initializeRuleEngineWorker(formDef, renderHTMLForm) {
   if (typeof Worker === 'undefined') {
     // No worker: fetch prefill only when enabled (worker path does the same in RuleEngineWorker.js)
     const needsPrefill = formDef?.properties?.['fd:formDataEnabled'] === true;
@@ -462,6 +462,32 @@ async function initializeRuleEngineWorker(formDef, renderHTMLForm) {
       captcha,
       data,
       generateFormRendition;
+    // While loadRuleEngine (triggered by restoreState) is still resolving the model
+    // import, formModels is not yet populated. Any applyFieldChanges batch that arrives
+    // in this window is buffered here and drained once restore completes, instead of
+    // being dropped. The live phase is unaffected (changes apply directly).
+    let restoreInProgress = false;
+    let pendingFieldChanges = [];
+
+    // Applies a worker field-change payload (batched array or single object) to both
+    // the DOM (fieldChanged) and the main-thread model copy (applyFieldChangeToFormModel).
+    async function processFieldChanges(changes, formModel) {
+      if (Array.isArray(changes)) {
+        if (form && formModel) {
+          await changes.reduce(
+            (promise, payload) => promise.then(async () => {
+              await fieldChanged(payload, form, generateFormRendition);
+              applyFieldChangeToFormModel(formModel, payload, true);
+            }),
+            Promise.resolve(),
+          );
+        }
+      } else if (changes) {
+        await fieldChanged(changes, form, generateFormRendition);
+        if (formModel) applyFieldChangeToFormModel(formModel, changes, true);
+      }
+    }
+
     myWorker.addEventListener('message', async (e) => {
       // main thread starts html rendering
       if (e.data.name === 'renderForm') {
@@ -480,26 +506,31 @@ async function initializeRuleEngineWorker(formDef, renderHTMLForm) {
 
       if (e.data.name === 'restoreState') {
         const { state } = e.data.payload;
-        loadRuleEngine(state, form, captcha, generateFormRendition, data);
+        // Set synchronously before awaiting: restoreState is delivered first, so a
+        // subsequent applyFieldChanges macrotask sees this flag and buffers instead
+        // of dropping its batch while formModels is still unset.
+        restoreInProgress = true;
+        await loadRuleEngine(state, form, captcha, generateFormRendition, data);
+        // formModels is now populated; drain anything buffered during the await.
+        const buffered = pendingFieldChanges;
+        pendingFieldChanges = [];
+        restoreInProgress = false;
+        const formModel = formModels[form?.dataset?.id];
+        await buffered.reduce(
+          (promise, changes) => promise.then(() => processFieldChanges(changes, formModel)),
+          Promise.resolve(),
+        );
       }
 
       if (e.data.name === 'applyFieldChanges') {
         const { fieldChanges: changes } = e.data.payload;
-        const formModel = formModels[form?.dataset?.id];
-        if (Array.isArray(changes)) {
-          if (form && formModel) {
-            await changes.reduce(
-              (promise, payload) => promise.then(async () => {
-                await fieldChanged(payload, form, generateFormRendition);
-                applyFieldChangeToFormModel(formModel, payload, true);
-              }),
-              Promise.resolve(),
-            );
-          }
-        } else if (changes) {
-          await fieldChanged(changes, form, generateFormRendition);
-          if (formModel) applyFieldChangeToFormModel(formModel, changes, true);
+        // During restore, formModels is not ready yet; buffer to avoid dropping.
+        if (restoreInProgress) {
+          pendingFieldChanges.push(changes);
+          return;
         }
+        const formModel = formModels[form?.dataset?.id];
+        await processFieldChanges(changes, formModel);
       }
 
       if (e.data.name === 'applyLiveFormChange') {

--- a/docs/context/worker-sync-protocol.md
+++ b/docs/context/worker-sync-protocol.md
@@ -50,6 +50,12 @@ After the `setTimeout(0)` yield, Phase 1 and Phase 2 changes are merged into a s
 **Main Thread Handling:**
 - Applied sequentially with `fieldChanged()` (DOM update) + `applyFieldChangeToFormModel()` (model sync)
 
+### Restore Buffering
+
+The `restoreState` and `applyFieldChanges` messages are posted back-to-back by the worker, but the main thread's `restoreState` handler must first `await loadRuleEngine()`, whose dynamic `import()` of the model can span multiple macrotasks. Because each worker message is delivered as its own macrotask, the batched `applyFieldChanges` can arrive while `loadRuleEngine` is still resolving — before `formModels` is populated.
+
+To prevent the batch from being dropped, `initializeRuleEngineWorker` keeps a `restoreInProgress` flag (set synchronously when `restoreState` is received) and a `pendingFieldChanges` buffer. While restore is in progress, incoming `applyFieldChanges` batches are buffered; immediately after `loadRuleEngine` completes they are drained and applied. The live phase is unaffected — once restore is done, changes apply directly.
+
 ### Phase 3: Live (after sync-complete)
 
 **Flags:**

--- a/test/unit/rules.test.js
+++ b/test/unit/rules.test.js
@@ -5,7 +5,7 @@
  */
 import assert from 'assert';
 import Sinon from 'sinon';
-import { loadRuleEngine } from '../../blocks/form/rules/index.js';
+import { loadRuleEngine, initializeRuleEngineWorker } from '../../blocks/form/rules/index.js';
 
 describe('Rule engine', () => {
   const formId = 'test-form-id';
@@ -41,6 +41,130 @@ describe('Rule engine', () => {
       await loadRuleEngine(minimalFormState, htmlForm, null, Sinon.stub(), null);
 
       assert.ok(global.window.myForm);
+    });
+  });
+
+  // Regression: the worker posts restoreState then applyFieldChanges back-to-back.
+  // restoreState's handler awaits loadRuleEngine (whose dynamic model import spans
+  // macrotasks), so applyFieldChanges can arrive before formModels is populated.
+  // The batch must be buffered during restore and drained afterwards, not dropped.
+  describe('initializeRuleEngineWorker (restore buffering)', () => {
+    const minimalFormState = {
+      id: formId,
+      action: '/submit',
+      ':itemsOrder': [],
+      metadata: {},
+      adaptiveform: '0.10.0',
+    };
+
+    const enumPayload = {
+      field: {
+        id: 'dd1',
+        name: 'dd1',
+        fieldType: 'drop-down',
+        ':type': 'drop-down',
+        type: 'string',
+        enum: ['Bangkok', 'Chiang Mai', 'Phuket'],
+        enumNames: ['Bangkok', 'Chiang Mai', 'Phuket'],
+      },
+      changes: [{ propertyName: 'enum', currentValue: ['Bangkok', 'Chiang Mai', 'Phuket'] }],
+    };
+
+    let originalWorker;
+    let htmlForm;
+    let select;
+
+    function buildRenderResponse() {
+      htmlForm = document.createElement('form');
+      htmlForm.dataset.id = formId;
+      const wrapper = document.createElement('div');
+      wrapper.className = 'field-wrapper';
+      wrapper.dataset.id = 'dd1';
+      select = document.createElement('select');
+      select.id = 'dd1';
+      ['Item 1', 'Item 2'].forEach((text) => {
+        const opt = document.createElement('option');
+        opt.textContent = text;
+        select.append(opt);
+      });
+      wrapper.append(select);
+      htmlForm.append(wrapper);
+      document.body.append(htmlForm);
+      return {
+        form: htmlForm,
+        captcha: null,
+        data: null,
+        generateFormRendition: Sinon.stub(),
+      };
+    }
+
+    beforeEach(() => {
+      originalWorker = global.Worker;
+      global.window.hlx = { codeBasePath: '' };
+      // Mock Worker so the worker code path runs (JSDOM has no Worker). Messages are
+      // emitted via microtasks (mirroring async worker delivery), and on 'decorated'
+      // the restoreState/applyFieldChanges/sync-complete trio is posted back-to-back
+      // to reproduce the restore race.
+      class MockWorker {
+        constructor() {
+          this.listeners = {};
+        }
+
+        addEventListener(type, cb) {
+          this.listeners[type] = this.listeners[type] || [];
+          this.listeners[type].push(cb);
+        }
+
+        // eslint-disable-next-line class-methods-use-this
+        removeEventListener() {}
+
+        // eslint-disable-next-line class-methods-use-this
+        terminate() {}
+
+        emit(data) {
+          Promise.resolve().then(() => {
+            (this.listeners.message || []).forEach((cb) => cb({ data }));
+          });
+        }
+
+        postMessage(msg) {
+          if (msg.name === 'createFormInstance') {
+            this.emit({ name: 'renderForm', payload: minimalFormState });
+          } else if (msg.name === 'decorated') {
+            this.emit({ name: 'restoreState', payload: { state: minimalFormState } });
+            this.emit({ name: 'applyFieldChanges', payload: { fieldChanges: [enumPayload] } });
+            this.emit({ name: 'sync-complete' });
+          }
+        }
+      }
+      global.Worker = MockWorker;
+    });
+
+    afterEach(() => {
+      if (originalWorker === undefined) {
+        delete global.Worker;
+      } else {
+        global.Worker = originalWorker;
+      }
+      if (htmlForm && htmlForm.parentNode) {
+        htmlForm.parentNode.removeChild(htmlForm);
+      }
+    });
+
+    it('buffers field changes that arrive during restore and applies them (does not drop the batch)', async () => {
+      const renderHTMLForm = Sinon.stub().callsFake(async () => buildRenderResponse());
+
+      await initializeRuleEngineWorker({ id: formId }, renderHTMLForm);
+      // Let renderForm -> decorated -> restoreState -> loadRuleEngine -> drain settle.
+      await new Promise((r) => { setTimeout(r, 100); });
+
+      const optionTexts = Array.from(select.options).map((o) => o.textContent);
+      assert.deepStrictEqual(
+        optionTexts,
+        ['Bangkok', 'Chiang Mai', 'Phuket'],
+        'dropdown should render the buffered enum options instead of the defaults',
+      );
+      assert.ok(global.window.myForm, 'window.myForm should be set after restore');
     });
   });
 });


### PR DESCRIPTION
## Problem

API-populated form fields (e.g. a dropdown whose `enum` is fetched via a custom function) end up **correct in the runtime model (`window.myForm`) but stale in the DOM** — the rendered `<select>` keeps its default options while the model holds the fetched list.

## Root cause

During init the worker posts three messages back-to-back: `restoreState → applyFieldChanges (batched) → sync-complete`.

The main thread's `restoreState` handler does `await loadRuleEngine(...)`, whose dynamic `import('./model/afb-runtime.js')` **spans multiple macrotasks**. Because each worker message is its own macrotask (and `await` only suspends the *restoreState* handler invocation, not the listener), the `applyFieldChanges` macrotask runs **while `formModels[id]` is still `undefined`**. Its guard `if (form && formModel)` is false, so the entire batched replay — including the `enum` change that re-renders the dropdown — is **silently dropped**. The model copy stays correct because `restoreFormInstance(state)` builds it from the restored state.

## Fix

Reintroduce the proven `forms-engine` mechanism — a `restoreInProgress` flag + `pendingFieldChanges` buffer:

- `restoreInProgress` set **synchronously** when `restoreState` arrives (before the `await`).
- While restore is in progress, `applyFieldChanges` batches are **buffered** instead of dropped.
- After `loadRuleEngine` completes (and `formModels` is populated), the buffer is **drained** and applied.
- Live/steady-state path **untouched** — no added promises/awaits per interaction.
- Extracted `processFieldChanges()` reused by the live handler and the drain (identical applied behavior).

## Tests

- Added a regression test that mocks `Worker`, reproduces the restore race, and asserts the dropdown renders the batched enum options rather than the defaults. **Verified it fails without the buffer.**
- No new failures in the unit suite.
- Documented in `docs/context/worker-sync-protocol.md` (new "Restore Buffering" subsection).

## Verification

Confirmed live: the affected dropdown now renders all 77 options matching the model.

Test URLs:

- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://restore-buffer-fix--aem-boilerplate-forms--adobe-rnd.aem.live/

🤖 Generated with [Claude Code](https://claude.com/claude-code)