### PR TITLE
fix(rules): forward live field model to listenChanges subscribers

### DIFF
--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -403,7 +403,11 @@ export async function loadRuleEngine(formDef, htmlForm, captcha, genFormRenditio
       const sub = subs?.get(fieldId);
       if (sub?.listenChanges) {
         try {
-          sub.callback(sub.fieldDiv, e.payload.field, 'change', e.payload);
+          // Pass the LIVE field model, not e.payload.field (a getState() snapshot), so the callback
+          // reads current getters/properties/methods — consistent with the 'register' call above.
+          // Falls back to the snapshot if the element can't be resolved (defensive).
+          const liveField = form.getElement(fieldId) || e.payload.field;
+          sub.callback(sub.fieldDiv, liveField, 'change', e.payload);
         } catch (err) {
           console.error(`Error in subscription callback for field "${fieldId}":`, err);
         }

--- a/test/unit/rules.test.js
+++ b/test/unit/rules.test.js
@@ -5,7 +5,7 @@
  */
 import assert from 'assert';
 import Sinon from 'sinon';
-import { loadRuleEngine } from '../../blocks/form/rules/index.js';
+import { loadRuleEngine, subscribe } from '../../blocks/form/rules/index.js';
 
 describe('Rule engine', () => {
   const formId = 'test-form-id';
@@ -41,6 +41,50 @@ describe('Rule engine', () => {
       await loadRuleEngine(minimalFormState, htmlForm, null, Sinon.stub(), null);
 
       assert.ok(global.window.myForm);
+    });
+  });
+
+  describe('subscribe listenChanges — forwards the LIVE field model, not a getState() snapshot', () => {
+    // A form with one text field so we can subscribe to it and drive a change.
+    const fieldId = 'field-1';
+    const formWithField = {
+      id: formId,
+      action: '/submit',
+      metadata: {},
+      adaptiveform: '0.10.0',
+      items: [
+        {
+          id: fieldId, name: 'field1', fieldType: 'text-input', type: 'string',
+        },
+      ],
+    };
+
+    it('the change callback receives the live model (has methods/getters), not e.payload.field', async () => {
+      const htmlForm = document.createElement('form');
+      htmlForm.dataset.id = formId;
+      // The DOM wrapper the component would register; its dataset.id must match the field id.
+      const fieldDiv = document.createElement('div');
+      fieldDiv.dataset.id = fieldId;
+      htmlForm.appendChild(fieldDiv);
+
+      await loadRuleEngine(formWithField, htmlForm, null, Sinon.stub(), null);
+      const form = global.window.myForm;
+      const liveField = form.getElement(fieldId);
+
+      const changeArgs = [];
+      subscribe(fieldDiv, formId, (el, model, eventType, payload) => {
+        if (eventType === 'change') { changeArgs.push({ model, payload }); }
+      }, { listenChanges: true });
+
+      // Drive a real value change → fieldChanged fires and the subscription callback runs.
+      liveField.value = 'hello';
+
+      assert.strictEqual(changeArgs.length > 0, true, 'change callback should have fired');
+      const { model } = changeArgs[changeArgs.length - 1];
+      // The live model is the SAME object af-core holds, exposing methods a getState() snapshot lacks.
+      assert.strictEqual(model, liveField, 'callback should receive the live field model');
+      assert.strictEqual(typeof model.getState, 'function', 'live model exposes getState()');
+      assert.strictEqual(model.value, 'hello', 'live model reflects the current value');
     });
   });
 });


### PR DESCRIPTION
## Problem
The `fieldChanged` subscription callback forwards `e.payload.field` to component `change` callbacks. That is a **`getState()` snapshot** (a plain object — see `afb-runtime` where `FieldChanged` is constructed from `action.target.getState()`), not the live field model. So a component's `change` handler reads stale, plain data with no live getters or methods — while the **`register`** callback in the same `subscribe()` already hands over the live model (`form.getElement(...)`). The two callbacks disagree on what a "fieldModel" is.

## Fix
Resolve the live model via `form.getElement(fieldId)` (defensive fallback to the snapshot) before invoking the `change` callback, so `register` and `change` pass components the same live object — matching the `subscribe()` JSDoc contract.

## Test
`test/unit/rules.test.js`: subscribe a field with `listenChanges`, drive a real value change, and assert the callback receives the live model (`=== form.getElement(id)`, exposes `getState()`, reflects the current value) — not the snapshot. Verified it fails on the old `e.payload.field` path. Full unit suite green (250 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)